### PR TITLE
Remove the FIXME comment

### DIFF
--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -57,7 +57,6 @@ module DoubleEntry
         credit.detail,  debit.detail  = detail, detail
         credit.balance, debit.balance = credit_balance.balance, debit_balance.balance
 
-        # FIXME: I don't think we use this.
         credit.partner_account, debit.partner_account = to, from
 
         credit.save!


### PR DESCRIPTION
This comment was wrong. I just deleted it.

Actually this line is important, because it sets up the reverse association to the one in line 54. The ids to this reverse association are set in lines 63 and 65
