### PR TITLE
Use a local tmp dir

### DIFF
--- a/spec/generators/double_entry/install/install_generator_spec.rb
+++ b/spec/generators/double_entry/install/install_generator_spec.rb
@@ -7,7 +7,7 @@ require 'generators/double_entry/install/install_generator'
 describe DoubleEntry::Generators::InstallGenerator do
   include GeneratorSpec::TestCase
 
-  destination File.expand_path("/tmp", __FILE__)
+  destination File.expand_path("../../../../../tmp", __FILE__)
 
   before do
     prepare_destination


### PR DESCRIPTION
We should not use the `tmp` folder in `root` as a temporary directory for our specs. Let's use the root of your gem instead. That folder is in `.gitignore` already.
