### PR TITLE
Remove describe, description methods

### DIFF
--- a/lib/double_entry.rb
+++ b/lib/double_entry.rb
@@ -186,17 +186,6 @@ module DoubleEntry
       DoubleEntry::Locking.lock_accounts(*accounts, &block)
     end
 
-    # @api private
-    def describe(line)
-      # make sure we have a test for this refactoring, the test
-      # conditions are: i forget... but it's important!
-      if line.credit?
-        configuration.transfers.find(line.account, line.partner_account, line.code)
-      else
-        configuration.transfers.find(line.partner_account, line.account, line.code)
-      end.description.call(line)
-    end
-
     # This is used by the concurrency test script.
     #
     # @api private

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -122,10 +122,6 @@ module DoubleEntry
       amount > Money.empty
     end
 
-    def description
-     DoubleEntry.describe(self)
-    end
-
     # Query out just the id and created_at fields for lines, without
     # instantiating any ActiveRecord objects.
     def self.find_id_and_created_at(options)

--- a/spec/double_entry_spec.rb
+++ b/spec/double_entry_spec.rb
@@ -215,11 +215,6 @@ describe DoubleEntry do
       expect(debit_line).to_not be_credit
     end
 
-    it 'can describe itself' do
-      expect(credit_line.description).to eq 'Money goes out: $-10.00'
-      expect(debit_line.description).to eq 'Money goes in: $10.00'
-    end
-
     it 'can reference its partner' do
       expect(credit_line.partner).to eq debit_line
       expect(debit_line.partner).to eq credit_line


### PR DESCRIPTION
Remove `DoubleEntry::describe` & `DoubleEntry::Line#description` methods.

We have no current use case for them.
