### PR TITLE
convenience method for defining active record scope identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,7 @@ require 'double_entry'
 
 DoubleEntry.configure do |config|
   config.define_accounts do |accounts|
-    user_scope = lambda do |user_identifier|
-      if user_identifier.is_a?(User)
-        user_identifier.id
-      else
-        user_identifier
-      end
-    end
-
+    user_scope = accounts.active_record_scope_identifier(User)
     accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
     accounts.define(:identifier => :checking, :scope_identifier => user_scope)
   end

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -30,7 +30,7 @@ module DoubleEntry
         end
       end
 
-      def ar_scope_identifier(active_record_class)
+      def active_record_scope_identifier(active_record_class)
         ActiveRecordScopeFactory.new(active_record_class).scope_identifier
       end
     end

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -31,8 +31,8 @@ module DoubleEntry
       end
     end
 
-    describe "#ar_scope_identifier" do
-      subject(:scope) { Account::Set.new.ar_scope_identifier(ar_class) }
+    describe "#active_record_scope_identifier" do
+      subject(:scope) { Account::Set.new.active_record_scope_identifier(ar_class) }
 
       context "given ActiveRecordScopeFactory is stubbed" do
         let(:scope_identifier) { double(:scope_identifier) }

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -4,7 +4,7 @@ DoubleEntry.configure do |config|
 
   # A set of accounts to test with
   config.define_accounts do |accounts|
-    user_scope = accounts.ar_scope_identifier(User)
+    user_scope = accounts.active_record_scope_identifier(User)
     accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
     accounts.define(:identifier => :checking, :scope_identifier => user_scope, :positive_only => true)
     accounts.define(:identifier => :test,     :scope_identifier => user_scope)


### PR DESCRIPTION
We can now define ActiveRecord scope identifiers, along with accounts, thusly:

``` ruby
  DoubleEntry.configure do |config|
    config.define_accounts do |accounts|
      user_scope = accounts.active_record_scope_identifier(User)
      accounts.define(:identifier => :checking, :scope_identifier => user_scope)
    end
  end
```

This fixes #40.
