### PR TITLE
specify version of i18n gem

### DIFF
--- a/gemfiles/Gemfile.rails-3.2.0
+++ b/gemfiles/Gemfile.rails-3.2.0
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gemspec :path => '../'
 
+gem 'i18n', '0.6.11'
 gem 'rails', '~>3.2.0'


### PR DESCRIPTION
Without this, a newer, non compatible version of the i18n gem will be used by rails 3.2 and the specs will fail
