### PR TITLE
Handle daylight savings time in WeekRange#from_time

### DIFF
--- a/lib/double_entry/reporting/week_range.rb
+++ b/lib/double_entry/reporting/week_range.rb
@@ -12,7 +12,7 @@ module DoubleEntry
       def from_time(time)
         time = time.to_time if time.is_a? Date
         year = time.end_of_week.year
-        week = ((time.beginning_of_week - start_of_year(year)) / 1.week).floor + 1
+        week = ((time.beginning_of_week - start_of_year(year) + dst_offset(time.beginning_of_week)) / 1.week).floor + 1
         new(:year => year, :week => week)
       end
 
@@ -38,6 +38,10 @@ module DoubleEntry
       end
 
     private
+
+      def dst_offset(time)
+        time.dst? ? 1.hour : 0
+      end
 
       def start_of_year(year)
         Time.local(year, 1, 1).beginning_of_week

--- a/spec/double_entry/reporting/week_range_spec.rb
+++ b/spec/double_entry/reporting/week_range_spec.rb
@@ -15,6 +15,14 @@ describe WeekRange do
     expect(range.start).to eq Time.parse("2010-12-27 00:00:00")
   end
 
+  it "handles daylight savings time properly" do
+    Time.use_zone('America/Los_Angeles') do
+      time = Time.zone.parse('Mon, 10 Mar 2014')
+      range = WeekRange.from_time time
+      expect(range.start.day).to eq 10
+    end
+  end
+
   describe "::from_time" do
     subject(:from_time) { WeekRange.from_time(given_time) }
 


### PR DESCRIPTION
Fixes issues with daylight savings time. (issue #60)
# 

**Before PR**:

``` ruby
Time.use_zone('America/Los_Angeles') do
  range = DoubleEntry::Reporting::WeekRange.from_time Time.zone.parse('Mon, 10 Mar 2014')
  range.start
end

# => 2014-03-03 00:00:00 -0800
```

**After PR**:

``` ruby
Time.use_zone('America/Los_Angeles') do
  range = DoubleEntry::Reporting::WeekRange.from_time Time.zone.parse('Mon, 10 Mar 2014')
  range.start
end

# => 2014-03-10 00:00:00 -0700
```
