### PR TITLE
Change WeekRange calculation to use Date#cweek

### DIFF
--- a/lib/double_entry/reporting/week_range.rb
+++ b/lib/double_entry/reporting/week_range.rb
@@ -10,9 +10,16 @@ module DoubleEntry
     class << self
 
       def from_time(time)
-        time = time.to_time if time.is_a? Date
-        year = time.end_of_week.year
-        week = ((time.beginning_of_week - start_of_year(year)) / 1.week).floor + 1
+        date = time.to_date
+        week = date.cweek
+        year = date.end_of_week.year
+
+        if date.beginning_of_week.year != year
+          week = 1
+        elsif date.beginning_of_year.cwday > Date::DAYNAMES.index('Thursday')
+          week += 1
+        end
+
         new(:year => year, :week => week)
       end
 

--- a/spec/double_entry/reporting/week_range_spec.rb
+++ b/spec/double_entry/reporting/week_range_spec.rb
@@ -15,6 +15,14 @@ describe WeekRange do
     expect(range.start).to eq Time.parse("2010-12-27 00:00:00")
   end
 
+  it "handles daylight savings time properly" do
+    Time.use_zone('America/Los_Angeles') do
+      time = Time.zone.parse('Mon, 10 Mar 2014')
+      range = WeekRange.from_time time
+      expect(range.start.day).to eq 10
+    end
+  end
+
   describe "::from_time" do
     subject(:from_time) { WeekRange.from_time(given_time) }
 


### PR DESCRIPTION
Fixes #60 

Removes the custom week calculation in favor of Ruby Date's [calendar week](http://ruby-doc.org/stdlib-2.1.3/libdoc/date/rdoc/Date.html#method-i-cweek) implementation.  This should handle all time zones in a more robust manner.

> [Ruby Date's] calendar week is a seven day period within a calendar year, starting on a Monday and identified by its ordinal number within the year; the first calendar week of the year is the one that includes the first Thursday of that year.

Two changes are made to Date's calendar week to fit DoubleEntry's desired implementation:
- Days which are in a week ending in a new year are set to Week 1.
- Years that start on a Friday, Saturday, or Sunday need the `cweek` to be incremented by one.

For confirmation, here is a printout of each day of the year as well as its corresponding week # and start date.  This matches up with the expected output.

https://gist.github.com/stavro/65f18bb6da2f5bf7fbe1
