### PR TITLE
allow self payments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-
 gemspec

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Rails Versions: Rails 3.2.x, 4.0.x, 4.1.x
 **Databases Supported:**
  * MySQL
  * PostgreSQL
+ * SQLite
 
 ## Installation
 
@@ -124,7 +125,7 @@ manually lock the accounts you're using:
 ```ruby
 DoubleEntry.lock_accounts(account_a, account_b) do
   # Perhaps transfer some money
-  DoubleEntry.transfer(20.dollars, :from => account_a, :to => account_b, :code => :purchase)
+  DoubleEntry.transfer(Money.new(20_00), :from => account_a, :to => account_b, :code => :purchase)
   # Perform other tasks that should be commited atomically with the transfer of funds...
 end
 ```
@@ -177,6 +178,19 @@ DoubleEntry.configure do |config|
   config.define_transfers do |transfers|
     transfers.define(:from => :checking, :to => :savings,  :code => :deposit)
     transfers.define(:from => :savings,  :to => :checking, :code => :withdraw)
+  end
+end
+```
+
+By default an account's currency is the same as Money.default_currency from the money gem.
+
+You can also specify a currency on a per account basis.
+Transfers between accounts of different currencies are not allowed.
+
+```ruby
+DoubleEntry.configure do |config|
+  config.define_accounts do |accounts|
+    accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :currency => :aud)
   end
 end
 ```
@@ -240,7 +254,7 @@ See the Github project [issues](https://github.com/envato/double_entry/issues).
     ./script/setup.sh
     ```
 
-3. Install MySQL and PostgreSQL. We run tests against both databases.
+3. Install MySQL, PostgreSQL and SQLite. We run tests against all three databases.
 4. Create a database in MySQL.
 
     ```sh
@@ -265,4 +279,3 @@ See the Github project [issues](https://github.com/envato/double_entry/issues).
     ```sh
     bundle exec rake
     ```
-

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'money',                 '>= 5.1.0'
-  gem.add_dependency 'encapsulate_as_money'
   gem.add_dependency 'activerecord',          '>= 3.2.9'
   gem.add_dependency 'activesupport',         '>= 3.0.0'
   gem.add_dependency 'railties',              '>= 3.0.0'

--- a/lib/double_entry.rb
+++ b/lib/double_entry.rb
@@ -3,7 +3,6 @@ require 'active_record'
 require 'active_record/locking_extensions'
 require 'active_support/all'
 require 'money'
-require 'encapsulate_as_money'
 
 require 'double_entry/version'
 require 'double_entry/errors'
@@ -127,6 +126,14 @@ module DoubleEntry
     # @return [Money] The balance
     def balance(account, options = {})
       BalanceCalculator.calculate(account, options)
+    end
+
+    # Get the currency of an account.
+    #
+    # @param [DoubleEntry::Account:Instance, Symbol] account Find the currency for this account
+    # @return [Currency] the currency
+    def currency(account)
+      Account.currency(configuration.accounts, account)
     end
 
     # Lock accounts in preparation for transfers.

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -9,6 +9,17 @@ module DoubleEntry
     end
 
     # @api private
+    def self.currency(defined_accounts, account)
+      code = account.is_a?(Symbol) ? account : account.identifier
+
+      found_account = defined_accounts.detect do |account|
+        account.identifier == code
+      end
+
+      found_account.currency
+    end
+
+    # @api private
     class Set < Array
       def define(attributes)
         self << Account.new(attributes)
@@ -47,7 +58,7 @@ module DoubleEntry
 
     class Instance
       attr_accessor :account, :scope
-      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :to => :account
+      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :currency, :to => :account
 
       def initialize(attributes)
         attributes.each { |name, value| send("#{name}=", value) }
@@ -93,7 +104,7 @@ module DoubleEntry
       end
 
       def to_s
-        "\#{Account account: #{identifier} scope: #{scope}}"
+        "\#{Account account: #{identifier} scope: #{scope} currency: #{currency}}"
       end
 
       def inspect
@@ -101,10 +112,11 @@ module DoubleEntry
       end
     end
 
-    attr_accessor :identifier, :scope_identifier, :positive_only
+    attr_accessor :identifier, :scope_identifier, :positive_only, :currency
 
     def initialize(attributes)
       attributes.each { |name, value| send("#{name}=", value) }
+      self.currency ||= Money.default_currency
     end
 
     def scoped?

--- a/lib/double_entry/account_balance.rb
+++ b/lib/double_entry/account_balance.rb
@@ -9,14 +9,25 @@ module DoubleEntry
   #
   # Account balances are created on demand when transfers occur.
   class AccountBalance < ActiveRecord::Base
-    extend EncapsulateAsMoney
 
-    encapsulate_as_money :balance
+    delegate :currency, :to => :account
+
+    def balance
+      self[:balance] && Money.new(self[:balance], currency)
+    end
+
+    def balance=(money)
+      self[:balance] = (money && money.fractional)
+    end
 
     def account=(account)
       self[:account] = account.identifier.to_s
       self[:scope] = account.scope_identity
       account
+    end
+
+    def account
+      DoubleEntry.account(self[:account].to_sym, :scope => self[:scope])
     end
 
     def self.find_by_account(account, options = {})
@@ -28,4 +39,3 @@ module DoubleEntry
   end
 
 end
-

--- a/lib/double_entry/balance_calculator.rb
+++ b/lib/double_entry/balance_calculator.rb
@@ -18,10 +18,11 @@ module DoubleEntry
       options = Options.new(account, args)
       relations = RelationBuilder.new(options)
       lines = relations.build
+      currency = DoubleEntry.currency(account)
 
       if options.between? || options.code?
         # from and to or code lookups have to be done via sum
-        Money.new(lines.sum(:amount))
+        Money.new(lines.sum(:amount), currency)
       else
         # all other lookups can be performed with running balances
         result = lines.
@@ -29,7 +30,7 @@ module DoubleEntry
           order('id DESC').
           limit(1).
           pluck(:balance)
-        result.empty? ? Money.empty : Money.new(result.first)
+        result.empty? ? Money.empty(currency) : Money.new(result.first, currency)
       end
     end
 

--- a/lib/double_entry/errors.rb
+++ b/lib/double_entry/errors.rb
@@ -7,5 +7,6 @@ module DoubleEntry
   class DuplicateAccount < RuntimeError; end
   class DuplicateTransfer < RuntimeError; end
   class AccountWouldBeSentNegative < RuntimeError; end
-
+  class MismatchedCurrencies < RuntimeError; end
+  class MissingAccountError < RuntimeError; end;
 end

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -28,7 +28,7 @@ module DoubleEntry
   # ```
   #
   # ### lines_scope_account_created_at_idx
-  # 
+  #
   # ```sql
   # ADD INDEX `lines_scope_account_created_at_idx` (scope, account, created_at)
   # ```
@@ -56,12 +56,25 @@ module DoubleEntry
   # by account, or account and code, over a particular period.
   #
   class Line < ActiveRecord::Base
-    extend EncapsulateAsMoney
 
     belongs_to :detail, :polymorphic => true
-    before_save :check_balance_will_not_be_sent_negative
+    before_save :do_validations
 
-    encapsulate_as_money :amount, :balance
+    def amount
+      self[:amount] && Money.new(self[:amount], currency)
+    end
+
+    def amount=(money)
+      self[:amount] = (money && money.fractional)
+    end
+
+    def balance
+      self[:balance] && Money.new(self[:balance], currency)
+    end
+
+    def balance=(money)
+      self[:balance] = (money && money.fractional)
+    end
 
     def code=(code)
       self[:code] = code.try(:to_s)
@@ -72,20 +85,26 @@ module DoubleEntry
       self[:code].try(:to_sym)
     end
 
-    def account=(account)
-      self[:account] = account.identifier.to_s
-      self.scope = account.scope_identity
-      account
+    def account=(_account)
+      self[:account] = _account.identifier.to_s
+      self.scope = _account.scope_identity
+      raise "Missing Account" unless account
+      _account
     end
 
     def account
       DoubleEntry.account(self[:account].to_sym, :scope => scope)
     end
 
-    def partner_account=(partner_account)
-      self[:partner_account] = partner_account.identifier.to_s
-      self.partner_scope = partner_account.scope_identity
-      partner_account
+    def currency
+      account.currency if self[:account]
+    end
+
+    def partner_account=(_partner_account)
+      self[:partner_account] = _partner_account.identifier.to_s
+      self.partner_scope = _partner_account.scope_identity
+      raise "Missing Partner Account" unless partner_account
+      _partner_account
     end
 
     def partner_account
@@ -122,6 +141,10 @@ module DoubleEntry
     end
 
     private
+
+    def do_validations
+      check_balance_will_not_be_sent_negative
+    end
 
     def check_balance_will_not_be_sent_negative
       if self.account.positive_only and self.balance < Money.new(0)

--- a/lib/double_entry/locking.rb
+++ b/lib/double_entry/locking.rb
@@ -162,7 +162,6 @@ module DoubleEntry
         @accounts_without_balances.each do |account|
           # Get the initial balance from the lines table.
           balance = account.balance
-
           # Try to create the balance record, but ignore it if someone else has done it in the meantime.
           AccountBalance.create_ignoring_duplicates!(:account => account, :balance => balance)
         end

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -54,13 +54,17 @@ module DoubleEntry
         where(:filter => filter.inspect).
         where(LineAggregate.arel_table[range_type].not_eq(nil)).
         inject({}) do |hash, result|
-          hash[result.key] = Aggregate.formatted_amount(function, result.amount)
+          hash[result.key] = Aggregate.formatted_amount(function, result.amount, currency)
           hash
         end
     end
 
     def all_periods
       TimeRangeArray.make(range_type, start, finish)
+    end
+
+    def currency
+      DoubleEntry.currency(account)
     end
   end
  end

--- a/lib/double_entry/reporting/line_aggregate.rb
+++ b/lib/double_entry/reporting/line_aggregate.rb
@@ -2,7 +2,6 @@
 module DoubleEntry
  module Reporting
   class LineAggregate < ActiveRecord::Base
-    extend EncapsulateAsMoney
 
     def self.aggregate(function, account, code, range, named_scopes)
       collection = aggregate_collection(named_scopes)

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -51,6 +51,11 @@ module DoubleEntry
     end
 
     def process(amount, from, to, code, detail)
+
+      if to.currency != from.currency
+        raise MismatchedCurrencies.new("Missmatched currency (#{to.currency} <> #{from.currency})")
+      end
+
       Locking.lock_accounts(from, to) do
         credit, debit = Line.new, Line.new
 

--- a/lib/double_entry/validation/line_check.rb
+++ b/lib/double_entry/validation/line_check.rb
@@ -4,7 +4,6 @@ require 'set'
 module DoubleEntry
  module Validation
   class LineCheck < ActiveRecord::Base
-    extend EncapsulateAsMoney
 
     default_scope -> { order('created_at') }
 

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -41,9 +41,9 @@ class CreateDoubleEntryTables < ActiveRecord::Migration
       t.integer  "day"
       t.integer  "hour"
       t.integer  "amount"
-      t.timestamps
       t.string   "filter"
       t.string   "range_type"
+      t.timestamps
     end
 
     add_index "double_entry_line_aggregates", ["function", "account", "code", "year", "month", "week", "day"], :name => "line_aggregate_idx"

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -20,6 +20,18 @@ module DoubleEntry
       expect(a1.hash).to eq a2.hash
       expect(a1.hash).to_not eq b.hash
     end
+
+    describe "currency" do
+      it "defaults to USD currency" do
+        account = DoubleEntry::Account.new(:identifier => "savings", :scope_identifier => identity_scope)
+        expect(DoubleEntry::Account::Instance.new(:account => account).currency).to eq("USD")
+      end
+
+      it "allows the currency to be set" do
+        account = DoubleEntry::Account.new(:identifier => "savings", :scope_identifier => identity_scope, :currency => "AUD")
+        expect(DoubleEntry::Account::Instance.new(:account => account).currency).to eq("AUD")
+      end
+    end
   end
 
   describe Account::Set do

--- a/spec/double_entry/balance_calculator_spec.rb
+++ b/spec/double_entry/balance_calculator_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 describe DoubleEntry::BalanceCalculator do
 
   describe '#calculate' do
-    let(:account) { double.as_null_object }
-    let(:scope) { nil }
+    let(:account) { DoubleEntry::account(:test, :scope => scope) }
+    let(:scope) { double(:id => 1) }
     let(:from) { nil }
     let(:to) { nil }
     let(:at) { nil }
@@ -28,10 +28,10 @@ describe DoubleEntry::BalanceCalculator do
 
     describe 'what happens with different accounts' do
       context 'when the given account is a symbol' do
-        let(:account) { :account }
+        let(:account) { :test }
 
         it 'scopes the lines summed by the account symbol' do
-          expect(DoubleEntry::Line).to have_received(:where).with(:account => 'account')
+          expect(DoubleEntry::Line).to have_received(:where).with(:account => 'test')
         end
 
         context 'with a scopeable entity provided' do
@@ -46,23 +46,6 @@ describe DoubleEntry::BalanceCalculator do
           it 'does not scope the lines summed by the given scope' do
             expect(relation).to_not have_received(:where).with(:scope => 'scope')
           end
-        end
-      end
-
-      context 'when the given account is DoubleEntry::Account-like' do
-        let(:account) do
-          DoubleEntry::Account::Instance.new(
-            :account => DoubleEntry::Account.new(
-                          :identifier => 'account_identity',
-                          :scope_identifier => lambda { |scope_id| scope_id },
-                        ),
-            :scope   => 'account_scope_identity'
-          )
-        end
-
-        it 'scopes the lines summed by the accounts identifier and its scope identity' do
-          expect(DoubleEntry::Line).to have_received(:where).with(:account => 'account_identity')
-          expect(relation).to have_received(:where).with(:scope => 'account_scope_identity')
         end
       end
     end

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -1,8 +1,11 @@
 # encoding: utf-8
 require "spec_helper"
 describe DoubleEntry::Line do
+  it "has a table name prefixed with double_entry_" do
+    expect(DoubleEntry::Line.table_name).to eq "double_entry_lines"
+  end
 
-  describe "persistent attributes" do
+  describe "persistance" do
     let(:persisted_line) {
       DoubleEntry::Line.new(
         :amount => Money.new(10_00),
@@ -15,34 +18,38 @@ describe DoubleEntry::Line do
     let(:account) { DoubleEntry.account(:test, :scope => "17") }
     let(:partner_account) { DoubleEntry.account(:test, :scope => "72") }
     let(:code) { :test_code }
-    before { persisted_line.save! }
     subject { DoubleEntry::Line.last }
 
-    context "given code = :the_code" do
-      let(:code) { :the_code }
-      its(:code) { should eq :the_code }
-    end
+    describe "attributes" do
+      before { persisted_line.save! }
 
-    context "given code = nil" do
-      let(:code) { nil }
-      its(:code) { should eq nil }
-    end
+      context "given code = :the_code" do
+        let(:code) { :the_code }
+        its(:code) { should eq :the_code }
+      end
 
-    context "given account = :test, 54 " do
-      let(:account) { DoubleEntry.account(:test, :scope => "54") }
-      its("account.account.identifier") { should eq :test }
-      its("account.scope") { should eq "54" }
-    end
+      context "given code = nil" do
+        let(:code) { nil }
+        its(:code) { should eq nil }
+      end
 
-    context "given partner_account = :test, 91 " do
-      let(:partner_account) { DoubleEntry.account(:test, :scope => "91") }
-      its("partner_account.account.identifier") { should eq :test }
-      its("partner_account.scope") { should eq "91" }
+      context "given account = :test, 54 " do
+        let(:account) { DoubleEntry.account(:test, :scope => "54") }
+        its("account.account.identifier") { should eq :test }
+        its("account.scope") { should eq "54" }
+      end
+
+      context "given partner_account = :test, 91 " do
+        let(:partner_account) { DoubleEntry.account(:test, :scope => "91") }
+        its("partner_account.account.identifier") { should eq :test }
+        its("partner_account.scope") { should eq "91" }
+      end
+
+      context "currency" do
+        let(:account) { DoubleEntry.account(:btc_test, :scope => "17") }
+        let(:partner_account) { DoubleEntry.account(:btc_test, :scope => "72") }
+        its(:currency) { should eq "BTC" }
+      end
     end
   end
-
-  it "has a table name prefixed with double_entry_" do
-    expect(DoubleEntry::Line.table_name).to eq "double_entry_lines"
-  end
-
 end

--- a/spec/double_entry/locking_spec.rb
+++ b/spec/double_entry/locking_spec.rb
@@ -51,8 +51,8 @@ describe DoubleEntry::Locking do
   end
 
   it "takes the balance for new account balance records from the lines table" do
-    DoubleEntry::Line.create!(:account => @account_a, :amount => Money.new(3_00), :balance => Money.new( 3_00), :code => :test)
-    DoubleEntry::Line.create!(:account => @account_a, :amount => Money.new(7_00), :balance => Money.new(10_00), :code => :test)
+    DoubleEntry::Line.create!(:account => @account_a, :partner_account => @account_b, :amount => Money.new(3_00), :balance => Money.new( 3_00), :code => :test)
+    DoubleEntry::Line.create!(:account => @account_a, :partner_account => @account_b, :amount => Money.new(7_00), :balance => Money.new(10_00), :code => :test)
 
     expect do
       DoubleEntry::Locking.lock_accounts(@account_a) { }

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -8,12 +8,13 @@ module DoubleEntry
       let(:finish) { nil }
       let(:range_type) { 'year' }
       let(:function) { :sum }
-
+      let(:account) { :savings }
+      let(:transfer_code) { :bonus }
       subject(:aggregate_array) {
         Reporting.aggregate_array(
           function,
-          :savings,
-          :bonus,
+          account,
+          transfer_code,
           :range_type => range_type,
           :start => start,
           :finish => finish,
@@ -67,6 +68,20 @@ module DoubleEntry
             it { should eq [ Money.new(0), Money.new(0), Money.new(10_00), Money.new(0), Money.new(20_00), Money.new(0), Money.new(0) ] }
           end
         end
+      end
+
+      context 'when account is in BTC currency' do
+        let(:account) { :btc_savings }
+        let(:range_type) { 'year' }
+        let(:start) { "#{Time.now.year}-01-01" }
+        let(:transfer_code) { :btc_test_transfer }
+
+        before do
+          perform_btc_deposit(user, 100_000_000)
+          perform_btc_deposit(user, 100_000_000)
+        end
+
+        it { should eq [ Money.new(200_000_000, :btc) ] }
       end
 
       context 'when called with range type of "invalid_and_should_not_work"' do

--- a/spec/double_entry/reporting/aggregate_spec.rb
+++ b/spec/double_entry/reporting/aggregate_spec.rb
@@ -203,5 +203,18 @@ module DoubleEntry
         end
       end
     end
+    describe Aggregate, "currencies" do
+      let(:user) { User.make! }
+      before do
+        perform_btc_deposit(user, 100_000_000)
+        perform_btc_deposit(user, 200_000_000)
+      end
+
+      it 'should calculate the sum in the correct currency' do
+        expect(
+          Reporting.aggregate(:sum, :btc_savings, :btc_test_transfer, :range => TimeRange.make(:year => Time.now.year))
+        ).to eq Money.new(300_000_000, :btc)
+      end
+    end
   end
 end

--- a/spec/double_entry_spec.rb
+++ b/spec/double_entry_spec.rb
@@ -97,17 +97,20 @@ describe DoubleEntry do
           accounts.define(:identifier => :savings)
           accounts.define(:identifier => :cash)
           accounts.define(:identifier => :trash)
+          accounts.define(:identifier => :bitbucket, :currency => :btc)
         end
 
         config.define_transfers do |transfers|
           transfers.define(:from => :savings, :to => :cash, :code => :xfer)
+          transfers.define(:from => :trash, :to => :bitbucket, :code => :mismatch_xfer)
         end
       end
     end
 
-    let(:savings) { DoubleEntry.account(:savings) }
-    let(:cash)    { DoubleEntry.account(:cash) }
-    let(:trash)   { DoubleEntry.account(:trash) }
+    let(:savings)   { DoubleEntry.account(:savings) }
+    let(:cash)      { DoubleEntry.account(:cash) }
+    let(:trash)     { DoubleEntry.account(:trash) }
+    let(:bitbucket) { DoubleEntry.account(:bitbucket) }
 
     it 'can transfer from an account to an account, if the transfer is allowed' do
       DoubleEntry.transfer(
@@ -148,6 +151,17 @@ describe DoubleEntry do
           :to   => trash,
         )
       }.to raise_error DoubleEntry::TransferNotAllowed
+    end
+
+    it 'raises an exception when the transfer is not allowed (mismatched currencies)' do
+      expect {
+        DoubleEntry.transfer(
+          Money.new(100_00),
+          :from => trash,
+          :to   => bitbucket,
+          :code => :mismatch_xfer
+        )
+      }.to raise_error DoubleEntry::MismatchedCurrencies
     end
   end
 
@@ -219,10 +233,12 @@ describe DoubleEntry do
 
   describe 'balances' do
 
-    let(:work)    { DoubleEntry.account(:work) }
-    let(:savings) { DoubleEntry.account(:savings) }
-    let(:cash)    { DoubleEntry.account(:cash) }
-    let(:store)   { DoubleEntry.account(:store) }
+    let(:work)       { DoubleEntry.account(:work) }
+    let(:savings)    { DoubleEntry.account(:savings) }
+    let(:cash)       { DoubleEntry.account(:cash) }
+    let(:store)      { DoubleEntry.account(:store) }
+    let(:btc_store)  { DoubleEntry.account(:btc_store) }
+    let(:btc_wallet) { DoubleEntry.account(:btc_wallet) }
 
     before do
       DoubleEntry.configure do |config|
@@ -231,6 +247,8 @@ describe DoubleEntry do
           accounts.define(:identifier => :cash)
           accounts.define(:identifier => :savings)
           accounts.define(:identifier => :store)
+          accounts.define(:identifier => :btc_store, :currency => 'BTC')
+          accounts.define(:identifier => :btc_wallet, :currency => 'BTC')
         end
 
         config.define_transfers do |transfers|
@@ -240,6 +258,7 @@ describe DoubleEntry do
           transfers.define(:code => :purchase, :from => :cash,    :to => :store)
           transfers.define(:code => :layby,    :from => :cash,    :to => :store)
           transfers.define(:code => :deposit,  :from => :cash,    :to => :store)
+          transfers.define(:code => :btc_ex,   :from => :btc_store,    :to => :btc_wallet)
         end
       end
 
@@ -267,7 +286,8 @@ describe DoubleEntry do
       end
 
       Timecop.freeze 1.week.from_now do
-        # go to the star wars convention AND ROCK OUT IN YOUR ACE DARTH VADER COSTUME!!!
+        # it's the future, man
+        DoubleEntry.transfer(Money.new(200_00, 'BTC'), :from => btc_store, :code => :btc_ex, :to => btc_wallet)
       end
     end
 
@@ -276,12 +296,17 @@ describe DoubleEntry do
       expect(cash.balance).to eq Money.new(100_00)
       expect(savings.balance).to eq Money.new(300_00)
       expect(store.balance).to eq Money.new(600_00)
+      expect(btc_wallet.balance).to eq Money.new(200_00, 'BTC')
     end
 
     it 'should have correct account balance records' do
-      [work, cash, savings, store].each do |account|
+      [work, cash, savings, store, btc_wallet].each do |account|
         expect(DoubleEntry::AccountBalance.find_by_account(account).balance).to eq account.balance
       end
+    end
+
+    it 'should have correct account balance currencies' do
+      expect(DoubleEntry::AccountBalance.find_by_account(btc_wallet).balance.currency).to eq 'BTC'
     end
 
     it 'affects origin/destination balance after transfer' do
@@ -301,6 +326,10 @@ describe DoubleEntry do
 
     it 'can be queries between two points in time' do
       expect(cash.balance(:from => 3.weeks.ago, :to => 2.weeks.ago)).to eq Money.new(500_00)
+    end
+
+    it 'can be queried between two points in time, even in the future' do
+      expect(btc_wallet.balance(:from => Time.now, :to => 2.weeks.from_now)).to eq Money.new(200_00, 'BTC')
     end
 
     it 'can report on balances, scoped by code' do
@@ -341,6 +370,8 @@ describe DoubleEntry do
     end
 
     let(:bank) { DoubleEntry.account(:bank) }
+    let(:cash) { DoubleEntry.account(:cash) }
+    let(:savings) { DoubleEntry.account(:savings) }
 
     let(:john) { User.make! }
     let(:johns_cash) { DoubleEntry.account(:cash, :scope => john) }
@@ -380,5 +411,4 @@ describe DoubleEntry do
       expect(DoubleEntry.balance(:savings)).to eq ryans_savings.balance + johns_savings.balance
     end
   end
-
 end

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -5,15 +5,19 @@ DoubleEntry.configure do |config|
   # A set of accounts to test with
   config.define_accounts do |accounts|
     user_scope = accounts.active_record_scope_identifier(User)
-    accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :checking, :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :test,     :scope_identifier => user_scope)
+    accounts.define(:identifier => :savings,     :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :checking,    :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :test,        :scope_identifier => user_scope)
+    accounts.define(:identifier => :btc_test,    :scope_identifier => user_scope, :currency => "BTC")
+    accounts.define(:identifier => :btc_savings, :scope_identifier => user_scope, :currency => "BTC")
   end
 
   # A set of allowed transfers between accounts
   config.define_transfers do |transfers|
-    transfers.define(:from => :test, :to => :savings,  :code => :bonus)
-    transfers.define(:from => :test, :to => :checking, :code => :pay)
+    transfers.define(:from => :test,     :to => :savings,     :code => :bonus)
+    transfers.define(:from => :test,     :to => :checking,    :code => :pay)
+    transfers.define(:from => :savings,  :to => :test,        :code => :test_withdrawal)
+    transfers.define(:from => :btc_test, :to => :btc_savings, :code => :btc_test_transfer)
   end
 
 end

--- a/spec/support/double_entry_spec_helper.rb
+++ b/spec/support/double_entry_spec_helper.rb
@@ -16,4 +16,12 @@ module DoubleEntrySpecHelper
     )
   end
 
+  def perform_btc_deposit(user, amount)
+    DoubleEntry.transfer(Money.new(amount, :btc),
+      :from => DoubleEntry.account(:btc_test, :scope => user),
+      :to   => DoubleEntry.account(:btc_savings, :scope => user),
+      :code => :btc_test_transfer,
+    )
+  end
+
 end


### PR DESCRIPTION
I'm guessing this was disallowed as a sanity check, under the assumption that no one would ever want to do a transfer to and from the same account.

While this wouldn't be a common occurrence, I think it is possible that in weird cases, a self payment makes sense if you consider that double entry may be part of a larger system. A contrived example would be banking a cheque made out to your self. The cheque clearing system may decide that the cheque is valid, and process the transfer from your account, to your account, as the bank wants the 25c fee. The transaction would need to happen so it appeared on the customer's statement, and while the end result is no change, for all the records to match up the transfer would need to take place.

I don't see any particular danger in not prohibiting self payments.
