### PR TITLE
Prevent accounts from going positive

### DIFF
--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -80,7 +80,7 @@ module DoubleEntry
 
     class Instance
       attr_reader :account, :scope
-      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :currency, :to => :account
+      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :negative_only, :currency, :to => :account
 
       def initialize(args)
         @account = args[:account]
@@ -147,12 +147,13 @@ module DoubleEntry
       end
     end
 
-    attr_reader :identifier, :scope_identifier, :positive_only, :currency
+    attr_reader :identifier, :scope_identifier, :positive_only, :negative_only, :currency
 
     def initialize(args)
       @identifier = args[:identifier]
       @scope_identifier = args[:scope_identifier]
       @positive_only = args[:positive_only]
+      @negative_only = args[:negative_only]
       @currency = args[:currency] || Money.default_currency
       if identifier.length > Account.account_identifier_max_length
         raise AccountIdentifierTooLongError.new(

--- a/lib/double_entry/errors.rb
+++ b/lib/double_entry/errors.rb
@@ -9,6 +9,7 @@ module DoubleEntry
   class DuplicateAccount < RuntimeError; end
   class DuplicateTransfer < RuntimeError; end
   class AccountWouldBeSentNegative < RuntimeError; end
+  class AccountWouldBeSentPositive < RuntimeError; end
   class MismatchedCurrencies < RuntimeError; end
   class MissingAccountError < RuntimeError; end;
   class AccountScopeMismatchError < RuntimeError; end;

--- a/lib/double_entry/errors.rb
+++ b/lib/double_entry/errors.rb
@@ -9,7 +9,7 @@ module DoubleEntry
   class DuplicateAccount < RuntimeError; end
   class DuplicateTransfer < RuntimeError; end
   class AccountWouldBeSentNegative < RuntimeError; end
-  class AccountWouldBeSentPositive < RuntimeError; end
+  class AccountWouldBeSentPositiveError < RuntimeError; end
   class MismatchedCurrencies < RuntimeError; end
   class MissingAccountError < RuntimeError; end;
   class AccountScopeMismatchError < RuntimeError; end;

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -156,7 +156,7 @@ module DoubleEntry
         raise AccountWouldBeSentNegative.new(account)
       end
       if account.negative_only && balance > Money.zero
-        raise AccountWouldBeSentPositive.new(account)
+        raise AccountWouldBeSentPositiveError.new(account)
       end
     end
   end

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -76,12 +76,12 @@ module DoubleEntry
     end
 
     def save(*)
-      check_balance_will_not_be_sent_negative
+      check_balance_will_remain_valid
       super
     end
 
     def save!(*)
-      check_balance_will_not_be_sent_negative
+      check_balance_will_remain_valid
       super
     end
 
@@ -151,9 +151,12 @@ module DoubleEntry
 
     private
 
-    def check_balance_will_not_be_sent_negative
-      if self.account.positive_only and self.balance < Money.new(0)
+    def check_balance_will_remain_valid
+      if account.positive_only && balance < Money.zero
         raise AccountWouldBeSentNegative.new(account)
+      end
+      if account.negative_only && balance > Money.zero
+        raise AccountWouldBeSentPositive.new(account)
       end
     end
   end

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -56,7 +56,7 @@ describe DoubleEntry::Line do
 
     context 'when balance is sent negative' do
       let(:account) {
-        DoubleEntry.account(:savings, :scope => '17', :positive_only => true)
+        DoubleEntry.account(:a_positive_only_acc, :scope => '17')
       }
 
       let(:line) {
@@ -68,6 +68,23 @@ describe DoubleEntry::Line do
 
       it 'raises AccountWouldBeSentNegative exception' do
         expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentNegative
+      end
+    end
+
+    context 'when balance is sent positive' do
+      let(:account) {
+        DoubleEntry.account(:a_negative_only_acc, :scope => '17')
+      }
+
+      let(:line) {
+        DoubleEntry::Line.new(
+          :balance => Money.new(1),
+          :account => account,
+        )
+      }
+
+      it 'raises AccountWouldBeSentPositive exception' do
+        expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentPositive
       end
     end
 

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -55,36 +55,22 @@ describe DoubleEntry::Line do
     end
 
     context 'when balance is sent negative' do
-      let(:account) {
-        DoubleEntry.account(:a_positive_only_acc, :scope => '17')
-      }
+      before { DoubleEntry::Account.accounts.define(:identifier => :a_positive_only_acc, :positive_only => true) }
+      let(:account) { DoubleEntry.account(:a_positive_only_acc) }
+      let(:line) { DoubleEntry::Line.new(:balance => Money.new(-1), :account => account) }
 
-      let(:line) {
-        DoubleEntry::Line.new(
-          :balance => Money.new(-1),
-          :account => account,
-        )
-      }
-
-      it 'raises AccountWouldBeSentNegative exception' do
+      it 'raises AccountWouldBeSentNegative error' do
         expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentNegative
       end
     end
 
     context 'when balance is sent positive' do
-      let(:account) {
-        DoubleEntry.account(:a_negative_only_acc, :scope => '17')
-      }
+      before { DoubleEntry::Account.accounts.define(:identifier => :a_negative_only_acc, :negative_only => true) }
+      let(:account) { DoubleEntry.account(:a_negative_only_acc) }
+      let(:line) { DoubleEntry::Line.new(:balance => Money.new(1), :account => account) }
 
-      let(:line) {
-        DoubleEntry::Line.new(
-          :balance => Money.new(1),
-          :account => account,
-        )
-      }
-
-      it 'raises AccountWouldBeSentPositive exception' do
-        expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentPositive
+      it 'raises AccountWouldBeSentPositiveError' do
+        expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentPositiveError
       end
     end
 

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -10,6 +10,9 @@ DoubleEntry.configure do |config|
     accounts.define(:identifier => :test,        :scope_identifier => user_scope)
     accounts.define(:identifier => :btc_test,    :scope_identifier => user_scope, :currency => "BTC")
     accounts.define(:identifier => :btc_savings, :scope_identifier => user_scope, :currency => "BTC")
+
+    accounts.define(:identifier => :a_positive_only_acc, :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :a_negative_only_acc, :scope_identifier => user_scope, :negative_only => true)
   end
 
   # A set of allowed transfers between accounts

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -10,9 +10,6 @@ DoubleEntry.configure do |config|
     accounts.define(:identifier => :test,        :scope_identifier => user_scope)
     accounts.define(:identifier => :btc_test,    :scope_identifier => user_scope, :currency => "BTC")
     accounts.define(:identifier => :btc_savings, :scope_identifier => user_scope, :currency => "BTC")
-
-    accounts.define(:identifier => :a_positive_only_acc, :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :a_negative_only_acc, :scope_identifier => user_scope, :negative_only => true)
   end
 
   # A set of allowed transfers between accounts


### PR DESCRIPTION
You can now define accounts as negative only.
```ruby
DoubleEntry.configure do |config|
  config.define_accounts do |accounts|
    accounts.define(
      :identifier => :my_account_that_never_goes_positive,
      :negative_only => true
    )
  end
end
```
If a transfer is requested that would take an account positive a `AccountWouldBeSentPositiveError` is raised.

Fixes #76 