### PR TITLE
Reduce build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ matrix:
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-3.2.x
       env: DB=mysql
+  exclude:
+    - rvm: 2.0.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
   - 2.1.5
 env:
   - DB=mysql
   - DB=postgres
+gemfile:
+  - spec/support/gemfiles/Gemfile.rails-4.1.x
+  - spec/support/gemfiles/Gemfile.rails-4.2.x
 before_script:
   - cp spec/support/database.travis.yml spec/support/database.yml
   - mysql -e 'create database double_entry_test;'
@@ -13,17 +15,14 @@ before_script:
 script:
   - rake spec
   - ruby script/jack_hammer -t 2000
-gemfile:
-  - spec/support/gemfiles/Gemfile.rails-4.1.x
-  - spec/support/gemfiles/Gemfile.rails-4.2.x
 matrix:
   include:
+    - rvm: 2.0.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
+      env: DB=mysql
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=sqlite
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-3.2.x
       env: DB=mysql
-  exclude:
-    - rvm: 2.0.0
-      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ script:
   - rake spec
   - ruby script/jack_hammer -t 2000
 gemfile:
-  - spec/support/gemfiles/Gemfile.rails-3.2.x
   - spec/support/gemfiles/Gemfile.rails-4.1.x
   - spec/support/gemfiles/Gemfile.rails-4.2.x
 matrix:
@@ -22,3 +21,6 @@ matrix:
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=sqlite
+    - rvm: 2.1.5
+      gemfile: spec/support/gemfiles/Gemfile.rails-3.2.x
+      env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,4 @@
 language: ruby
-rvm:
-  - 2.1.5
-env:
-  - DB=mysql
-gemfile:
-  - spec/support/gemfiles/Gemfile.rails-4.1.x
-  - spec/support/gemfiles/Gemfile.rails-4.2.x
 before_script:
   - cp spec/support/database.travis.yml spec/support/database.yml
   - mysql -e 'create database double_entry_test;'
@@ -19,6 +12,12 @@ matrix:
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql
     - rvm: 2.0.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
+      env: DB=mysql
+    - rvm: 2.1.5
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.1.x
+      env: DB=mysql
+    - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql
     - rvm: 2.1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
 env:
   - DB=mysql
   - DB=postgres
-  - DB=sqlite
 before_script:
   - cp spec/support/database.travis.yml spec/support/database.yml
   - mysql -e 'create database double_entry_test;'
@@ -18,3 +17,8 @@ gemfile:
   - spec/support/gemfiles/Gemfile.rails-3.2.x
   - spec/support/gemfiles/Gemfile.rails-4.1.x
   - spec/support/gemfiles/Gemfile.rails-4.2.x
+matrix:
+  include:
+    - rvm: 2.1.5
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
+      env: DB=sqlite

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.1.5
 env:
   - DB=mysql
-  - DB=postgres
 gemfile:
   - spec/support/gemfiles/Gemfile.rails-4.1.x
   - spec/support/gemfiles/Gemfile.rails-4.2.x
@@ -25,6 +24,9 @@ matrix:
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=sqlite
+    - rvm: 2.1.5
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
+      env: DB=postgres
     - rvm: 2.1.5
       gemfile: spec/support/gemfiles/Gemfile.rails-3.2.x
       env: DB=mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.1.5
 env:
   - DB=mysql
@@ -17,6 +16,9 @@ script:
   - ruby script/jack_hammer -t 2000
 matrix:
   include:
+    - rvm: 1.9.3
+      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
+      env: DB=mysql
     - rvm: 2.0.0
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql


### PR DESCRIPTION
We don't need to test every possible combination. Just enough to give confidence.

SQLite get's just one build.
As does PostgreSQL.
As does Rails 3.2.
As does Rails 4.1.
As does Ruby 1.9.3.
As does Ruby 2.0.0.