### PR TITLE
Print Ruby warnings to the console as generated by double_entry

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require "bundler/gem_tasks"
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.verbose = false
+  t.ruby_opts = '-w'
 end
 
 task :default do

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -39,11 +39,11 @@ module DoubleEntry
       end
 
       def find(identifier, scoped)
-        account = detect do |account|
+        found_account = detect do |account|
           account.identifier == identifier && account.scoped? == scoped
         end
-        raise UnknownAccount.new("account: #{identifier} scoped?: #{scoped}") unless account
-        return account
+        raise UnknownAccount.new("account: #{identifier} scoped?: #{scoped}") unless found_account
+        return found_account
       end
 
       def <<(account)

--- a/lib/double_entry/reporting/time_range.rb
+++ b/lib/double_entry/reporting/time_range.rb
@@ -43,6 +43,7 @@ module DoubleEntry
     def initialize(options)
       @year = options[:year]
       @range_type = options[:range_type] || :normal
+      @month = @week = @day = @hour = nil
     end
 
     def key

--- a/lib/double_entry/validation/line_check.rb
+++ b/lib/double_entry/validation/line_check.rb
@@ -55,7 +55,7 @@ module DoubleEntry
       # on the query to fail in some circumstances, resulting in an old balance being
       # returned. This was biting us intermittently in spec runs.
       # See http://bugs.mysql.com/bug.php?id=51431
-      force_index = if Line.connection.adapter_name.match /mysql/i
+      force_index = if Line.connection.adapter_name.match(/mysql/i)
                       "FORCE INDEX (lines_scope_account_id_idx)"
                     else
                       ""

--- a/spec/double_entry/validation/line_check_spec.rb
+++ b/spec/double_entry/validation/line_check_spec.rb
@@ -57,7 +57,7 @@ module DoubleEntry::Validation
         before { DoubleEntry::Line.order(:id).limit(1).update_all('balance = balance + 1') }
 
         its(:errors_found) { should be true }
-        its(:log) { should match /Error on line/ }
+        its(:log) { should match(/Error on line/) }
 
         it 'should correct the running balance' do
           expect {

--- a/spec/double_entry_spec.rb
+++ b/spec/double_entry_spec.rb
@@ -186,19 +186,19 @@ RSpec.describe DoubleEntry do
     let(:debit_line) { lines_for_account(account_b).first }
 
     it 'has an amount' do
-      expect(credit_line.amount).to eq -Money.new(10_00)
-      expect(debit_line.amount).to eq Money.new(10_00)
+      expect(credit_line.amount).to eq(Money.new(-10_00))
+      expect(debit_line.amount).to eq(Money.new(10_00))
     end
 
     it 'has a code' do
-      expect(credit_line.code).to eq :xfer
-      expect(debit_line.code).to eq :xfer
+      expect(credit_line.code).to eq(:xfer)
+      expect(debit_line.code).to eq(:xfer)
     end
 
     it 'auto-sets scope when assigning account (and partner_accout, is this implementation?)' do
-      expect(credit_line[:account]).to eq 'a'
+      expect(credit_line[:account]).to eq('a')
       expect(credit_line[:scope]).to be_nil
-      expect(credit_line[:partner_account]).to eq 'b'
+      expect(credit_line[:partner_account]).to eq('b')
       expect(credit_line[:partner_scope]).to be_nil
     end
 
@@ -214,18 +214,18 @@ RSpec.describe DoubleEntry do
     end
 
     it 'can reference its partner' do
-      expect(credit_line.partner).to eq debit_line
-      expect(debit_line.partner).to eq credit_line
+      expect(credit_line.partner).to eq(debit_line)
+      expect(debit_line.partner).to eq(credit_line)
     end
 
     it 'can ask for its pair (credit always coming first)' do
-      expect(credit_line.pair).to eq [credit_line, debit_line]
-      expect(debit_line.pair).to eq [credit_line, debit_line]
+      expect(credit_line.pair).to eq([ credit_line, debit_line ])
+      expect(debit_line.pair).to eq([ credit_line, debit_line ])
     end
 
     it 'can ask for the account (and get an instance)' do
-      expect(credit_line.account).to eq account_a
-      expect(debit_line.account).to eq account_b
+      expect(credit_line.account).to eq(account_a)
+      expect(debit_line.account).to eq(account_b)
     end
   end
 
@@ -290,21 +290,21 @@ RSpec.describe DoubleEntry do
     end
 
     it 'has the initial balances that we expect' do
-      expect(work.balance).to eq -Money.new(1_000_00)
-      expect(cash.balance).to eq Money.new(100_00)
-      expect(savings.balance).to eq Money.new(300_00)
-      expect(store.balance).to eq Money.new(600_00)
-      expect(btc_wallet.balance).to eq Money.new(200_00, 'BTC')
+      expect(work.balance).to eq(Money.new(-1_000_00))
+      expect(cash.balance).to eq(Money.new(100_00))
+      expect(savings.balance).to eq(Money.new(300_00))
+      expect(store.balance).to eq(Money.new(600_00))
+      expect(btc_wallet.balance).to eq(Money.new(200_00, 'BTC'))
     end
 
     it 'should have correct account balance records' do
       [work, cash, savings, store, btc_wallet].each do |account|
-        expect(DoubleEntry::AccountBalance.find_by_account(account).balance).to eq account.balance
+        expect(DoubleEntry::AccountBalance.find_by_account(account).balance).to eq(account.balance)
       end
     end
 
     it 'should have correct account balance currencies' do
-      expect(DoubleEntry::AccountBalance.find_by_account(btc_wallet).balance.currency).to eq 'BTC'
+      expect(DoubleEntry::AccountBalance.find_by_account(btc_wallet).balance.currency).to eq('BTC')
     end
 
     it 'affects origin/destination balance after transfer' do
@@ -314,20 +314,20 @@ RSpec.describe DoubleEntry do
 
       DoubleEntry.transfer(amount, :from => savings, :code => :xfer, :to => cash)
 
-      expect(savings.balance).to eq savings_balance - amount
-      expect(cash.balance).to eq cash_balance + amount
+      expect(savings.balance).to eq(savings_balance - amount)
+      expect(cash.balance).to eq(cash_balance + amount)
     end
 
     it 'can be queried at a given point in time' do
-      expect(cash.balance(:at => 1.week.ago)).to eq Money.new(100_00)
+      expect(cash.balance(:at => 1.week.ago)).to eq(Money.new(100_00))
     end
 
     it 'can be queries between two points in time' do
-      expect(cash.balance(:from => 3.weeks.ago, :to => 2.weeks.ago)).to eq Money.new(500_00)
+      expect(cash.balance(:from => 3.weeks.ago, :to => 2.weeks.ago)).to eq(Money.new(500_00))
     end
 
     it 'can be queried between two points in time, even in the future' do
-      expect(btc_wallet.balance(:from => Time.now, :to => 2.weeks.from_now)).to eq Money.new(200_00, 'BTC')
+      expect(btc_wallet.balance(:from => Time.now, :to => 2.weeks.from_now)).to eq(Money.new(200_00, 'BTC'))
     end
 
     it 'can report on balances, scoped by code' do
@@ -335,18 +335,18 @@ RSpec.describe DoubleEntry do
     end
 
     it 'can report on balances, scoped by many codes' do
-      expect(store.balance(:codes => [:layby, :deposit])).to eq Money.new(200_00)
+      expect(store.balance(:codes => [:layby, :deposit])).to eq(Money.new(200_00))
     end
 
     it 'has running balances for each line' do
       lines = lines_for_account(cash)
-      expect(lines[0].balance).to eq Money.new(1_000_00) # salary
-      expect(lines[1].balance).to eq Money.new(500_00) # savings
-      expect(lines[2].balance).to eq Money.new(300_00) # purchase
-      expect(lines[3].balance).to eq Money.new(200_00) # layby
-      expect(lines[4].balance).to eq Money.new(100_00) # deposit
-      expect(lines[5].balance).to eq Money.new(300_00) # savings
-      expect(lines[6].balance).to eq Money.new(100_00) # purchase
+      expect(lines[0].balance).to eq(Money.new(1_000_00)) # salary
+      expect(lines[1].balance).to eq(Money.new(500_00)) # savings
+      expect(lines[2].balance).to eq(Money.new(300_00)) # purchase
+      expect(lines[3].balance).to eq(Money.new(200_00)) # layby
+      expect(lines[4].balance).to eq(Money.new(100_00)) # deposit
+      expect(lines[5].balance).to eq(Money.new(300_00)) # savings
+      expect(lines[6].balance).to eq(Money.new(100_00)) # purchase
     end
   end
 
@@ -383,20 +383,20 @@ RSpec.describe DoubleEntry do
     it 'treats each separately scoped account having their own separate balances' do
       DoubleEntry.transfer(Money.new(20_00), :from => bank, :to => johns_cash, :code => :xfer)
       DoubleEntry.transfer(Money.new(10_00), :from => bank, :to => ryans_cash, :code => :xfer)
-      expect(johns_cash.balance).to eq Money.new(20_00)
-      expect(ryans_cash.balance).to eq Money.new(10_00)
+      expect(johns_cash.balance).to eq(Money.new(20_00))
+      expect(ryans_cash.balance).to eq(Money.new(10_00))
     end
 
     it 'allows transfer between two separately scoped accounts' do
       DoubleEntry.transfer(Money.new(10_00), :from => ryans_cash, :to => johns_cash, :code => :xfer)
-      expect(ryans_cash.balance).to eq -Money.new(10_00)
-      expect(johns_cash.balance).to eq Money.new(10_00)
+      expect(ryans_cash.balance).to eq(Money.new(-10_00))
+      expect(johns_cash.balance).to eq(Money.new(10_00))
     end
 
     it 'reports balance correctly if called from either account or finances object' do
       DoubleEntry.transfer(Money.new(10_00), :from => ryans_cash, :to => johns_cash, :code => :xfer)
-      expect(ryans_cash.balance).to eq -Money.new(10_00)
-      expect(DoubleEntry.balance(:cash, :scope => ryan)).to eq -Money.new(10_00)
+      expect(ryans_cash.balance).to eq(Money.new(-10_00))
+      expect(DoubleEntry.balance(:cash, :scope => ryan)).to eq(Money.new(-10_00))
     end
 
     it 'raises an exception if you try to scope with an object instance of differing class to that defined on the account' do
@@ -419,8 +419,8 @@ RSpec.describe DoubleEntry do
 
     it 'allows transfer from one persons account to the same persons other kind of account' do
       DoubleEntry.transfer(Money.new(100_00), :from => ryans_cash, :to => ryans_savings, :code => :xfer)
-      expect(ryans_cash.balance).to eq -Money.new(100_00)
-      expect(ryans_savings.balance).to eq Money.new(100_00)
+      expect(ryans_cash.balance).to eq(Money.new(-100_00))
+      expect(ryans_savings.balance).to eq(Money.new(100_00))
     end
 
     it 'disallows you to report on scoped accounts globally' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ FileUtils.mkdir_p 'log'
 FileUtils.rm 'log/test.log', :force => true
 
 database_config_file = File.expand_path("../support/database.yml", __FILE__)
-if File.exists?(database_config_file)
+if File.exist?(database_config_file)
   ActiveRecord::Base.establish_connection YAML.load_file(database_config_file)[db_engine]
 else
   puts "Please configure your spec/support/database.yml file."

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,12 +28,16 @@ end
 
 I18n.config.enforce_available_locales = false
 
+silence_warnings do
+  require 'rspec'
+  require 'rspec/its'
+  require 'database_cleaner'
+  require 'machinist/active_record'
+  require 'timecop'
+  require 'money'
+end
+
 require 'double_entry'
-require 'rspec'
-require 'rspec/its'
-require 'database_cleaner'
-require 'machinist/active_record'
-require 'timecop'
 
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }
 


### PR DESCRIPTION
Print Ruby warnings to the console during our test run. We don't want this gem producing warning as that would frustrate projects downstream.

If we notice any warnings, they should be fixed.