### PR TITLE
Fix circular arg reference

### DIFF
--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -25,7 +25,7 @@ module DoubleEntry
         end
       end
 
-      def formatted_amount(value = amount)
+      def formatted_amount(value = amount())
         value ||= 0
         if function == 'count'
           value


### PR DESCRIPTION
That would fix the circular argument reference warning

```
/opt/boxen/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/double_entry-0.10.0/lib/double_entry/reporting/aggregate.rb:28: warning: circular argument reference - amount
```