### PR TITLE
Fix AggregateArray

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -35,5 +35,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'machinist'
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'rubocop'
-  gem.add_development_dependency 'pry-byebug'
 end

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'machinist'
   gem.add_development_dependency 'timecop'
   gem.add_development_dependency 'rubocop'
+  gem.add_development_dependency 'pry-byebug'
 end

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -47,16 +47,16 @@ module DoubleEntry
       # get any previously calculated aggregates
       def retrieve_aggregates
         fail ArgumentError, "Invalid range type '#{range_type}'" unless %w(year month week day hour).include? range_type
-        @aggregates = LineAggregate.
-                      where(:function => function).
-                      where(:range_type => 'normal').
-                      where(:account => account.to_s).
-                      where(:code => code.to_s).
-                      where(:filter => filter.inspect).
-                      where(LineAggregate.arel_table[range_type].not_eq(nil)).
-                      each_with_object({}) do |hash, result|
-                        hash[result.key] = formatted_amount(result.amount)
-                      end
+        scope = LineAggregate.
+          where(:function => function).
+          where(:range_type => 'normal').
+          where(:account => account.to_s).
+          where(:code => code.to_s).
+          where(:filter => filter.inspect).
+          where(LineAggregate.arel_table[range_type].not_eq(nil))
+        @aggregates = scope.each_with_object({}) do |result, hash|
+          hash[result.key] = formatted_amount(result.amount)
+        end
       end
 
       def all_periods

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -53,7 +53,7 @@ module DoubleEntry
 
                   expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[2])
                   expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[3])
-                  subject
+                  aggregate_array
                 end
               end
             end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -36,6 +36,27 @@ module DoubleEntry
             let(:range_type) { 'year' }
             let(:start) { '2006-08-03' }
             it { should eq [Money.zero, Money.new(10_00), Money.new(20_00), Money.zero] }
+
+            describe 'reuse of aggregates' do
+              let(:years) { TimeRangeArray.make(range_type, start, finish) }
+
+              context 'and some aggregates were created previously' do
+                before do
+                  Reporting.aggregate(function.to_s, account, transfer_code, :filter => nil, :range => years[0])
+                  Reporting.aggregate(function.to_s, account, transfer_code, :filter => nil, :range => years[1])
+                  allow(Reporting).to receive(:aggregate)
+                end
+
+                it 'only asks Reporting for the non-existent ones' do
+                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[0])
+                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[1])
+
+                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[2])
+                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[3])
+                  subject
+                end
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
The retrieve_aggregates method in AggregateArray was never tested. It's causing  an ArgumentEror in Marketplace generic reports (and apparently has been since November 2014!).

Create a test to expose the ArgumentError bug in retrieve_aggregates. Fix the bug.