### PR TITLE
Don't warn about potential false positives

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ RSpec.configure do |config|
     # ...rather than:
     #   # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.warn_about_potential_false_positives = false
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
RSpec has introduced a warning when `expect {…}.to raise_error` without an explicit error type. We're doing this in some places because the type of error is dependent on the DB being used. We should clean this up. But not now. Let's silence those new RSpec warnings for now.