### PR TITLE
create the metadata table so that we can support filtering on lines

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |gem|
 
   gem.post_install_message = <<-'POSTINSTALLMESSAGE'
 Please note the following changes in DoubleEntry:
- - New table `double_entry_line_metadata` has been introduced and is required for
-   aggregate reporting filtering. Existing applications will have to manually
-   manage this change via a migration similar to the following:
+ - New table `double_entry_line_metadata` has been introduced and is *required* for
+   aggregate reporting filtering to work. Existing applications must manually manage
+   this change via a migration similar to the following:
 
     class CreateDoubleEntryLineMetadata < ActiveRecord::Migration
       def self.up
@@ -32,7 +32,9 @@ Please note the following changes in DoubleEntry:
           t.timestamps                          :null => false
         end
 
-        add_index "#{DoubleEntry.table_name_prefix}line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
+        add_index "#{DoubleEntry.table_name_prefix}line_metadata",
+                  ["line_id", "key", "value"],
+                  :name => "lines_meta_line_id_key_value_idx"
       end
 
       def self.down
@@ -40,7 +42,7 @@ Please note the following changes in DoubleEntry:
       end
     end
 
-  Please update your database accordingly.
+  Please ensure that you update your database accordingly.
 POSTINSTALLMESSAGE
 
   gem.add_dependency 'money',                 '>= 6.0.0'

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.post_install_message = <<-'POSTINSTALLMESSAGE'
-Please note the following changes in DoubleEntry version 10.4:
+Please note the following changes in DoubleEntry:
  - New table `double_entry_line_metadata` has been introduced and is required for
    aggregate reporting filtering. Existing applications will have to manually
    manage this change via a migration similar to the following:

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -31,6 +31,8 @@ Please note the following changes in DoubleEntry version 10.4:
           t.string     "value",   :limit => 64, :null => false
           t.timestamps                          :null => false
         end
+
+        add_index "#{DoubleEntry.table_name_prefix}line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
       end
 
       def self.down

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -17,6 +17,31 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
+  gem.post_install_message = <<-'POSTINSTALLMESSAGE'
+Please note the following changes in DoubleEntry version 10.4:
+ - New table `double_entry_line_metadata` has been introduced and is required for
+   aggregate reporting filtering. Existing applications will have to manually
+   manage this change via a migration similar to the following:
+
+    class CreateDoubleEntryLineMetadata < ActiveRecord::Migration
+      def self.up
+        create_table "#{DoubleEntry.table_name_prefix}line_metadata", :force => true do |t|
+          t.integer    "line_id",               :null => false
+          t.string     "key",     :limit => 48, :null => false
+          t.string     "value",   :limit => 64, :null => false
+          t.timestamps                          :null => false
+        end
+      end
+
+      def self.down
+        drop_table "#{DoubleEntry.table_name_prefix}line_metadata"
+      end
+    end
+
+  Please update your database accordingly.
+POSTINSTALLMESSAGE
+
+
   gem.add_dependency 'money',                 '>= 6.0.0'
   gem.add_dependency 'activerecord',          '>= 3.2.0'
   gem.add_dependency 'activesupport',         '>= 3.2.0'

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -43,7 +43,6 @@ Please note the following changes in DoubleEntry version 10.4:
   Please update your database accordingly.
 POSTINSTALLMESSAGE
 
-
   gem.add_dependency 'money',                 '>= 6.0.0'
   gem.add_dependency 'activerecord',          '>= 3.2.0'
   gem.add_dependency 'activesupport',         '>= 3.2.0'

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -62,8 +62,8 @@ class CreateDoubleEntryTables < ActiveRecord::Migration
       t.timestamps                          :null => false
     end
 
-    add_index "double_entry_line_metadata", ["key"]   :name => "lines_meta_key_idx"
-    add_index "double_entry_line_metadata", ["value"] :name => "lines_meta_value_idx"
+    add_index "double_entry_line_metadata", ["key"],   :name => "lines_meta_key_idx"
+    add_index "double_entry_line_metadata", ["value"], :name => "lines_meta_value_idx"
   end
 
   def self.down

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -62,9 +62,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration
       t.timestamps                          :null => false
     end
 
-    add_index "double_entry_line_metadata", ["line_id"], :name => "lines_meta_line_id_idx"
-    add_index "double_entry_line_metadata", ["key"],     :name => "lines_meta_key_idx"
-    add_index "double_entry_line_metadata", ["value"],   :name => "lines_meta_value_idx"
+    add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
   end
 
   def self.down

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -54,9 +54,20 @@ class CreateDoubleEntryTables < ActiveRecord::Migration
       t.text       "log"
       t.timestamps                             :null => false
     end
+
+    create_table "double_entry_line_metadata", :force => true do |t|
+      t.integer    "line_id",               :null => false
+      t.string     "key",     :limit => 48, :null => false
+      t.string     "value",   :limit => 64, :null => false
+      t.timestamps                          :null => false
+    end
+
+    add_index "double_entry_line_metadata", ["key"]   :name => "lines_meta_key_idx"
+    add_index "double_entry_line_metadata", ["value"] :name => "lines_meta_value_idx"
   end
 
   def self.down
+    drop_table "double_entry_line_metadata"
     drop_table "double_entry_line_checks"
     drop_table "double_entry_line_aggregates"
     drop_table "double_entry_lines"

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -62,8 +62,9 @@ class CreateDoubleEntryTables < ActiveRecord::Migration
       t.timestamps                          :null => false
     end
 
-    add_index "double_entry_line_metadata", ["key"],   :name => "lines_meta_key_idx"
-    add_index "double_entry_line_metadata", ["value"], :name => "lines_meta_value_idx"
+    add_index "double_entry_line_metadata", ["line_id"], :name => "lines_meta_line_id_idx"
+    add_index "double_entry_line_metadata", ["key"],     :name => "lines_meta_key_idx"
+    add_index "double_entry_line_metadata", ["value"],   :name => "lines_meta_value_idx"
   end
 
   def self.down

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -62,8 +62,9 @@ ActiveRecord::Schema.define do
     t.timestamps                          :null => false
   end
 
-  add_index "double_entry_line_metadata", ["key"],   :name => "lines_meta_key_idx"
-  add_index "double_entry_line_metadata", ["value"], :name => "lines_meta_value_idx"
+  add_index "double_entry_line_metadata", ["line_id"], :name => "lines_meta_line_id_idx"
+  add_index "double_entry_line_metadata", ["key"],     :name => "lines_meta_key_idx"
+  add_index "double_entry_line_metadata", ["value"],   :name => "lines_meta_value_idx"
 
   # test table only
   create_table "users", :force => true do |t|

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define do
     t.timestamps                          :null => false
   end
 
-  add_index "double_entry_line_metadata", ["key"]   :name => "lines_meta_key_idx"
-  add_index "double_entry_line_metadata", ["value"] :name => "lines_meta_value_idx"
+  add_index "double_entry_line_metadata", ["key"],   :name => "lines_meta_key_idx"
+  add_index "double_entry_line_metadata", ["value"], :name => "lines_meta_value_idx"
 
   # test table only
   create_table "users", :force => true do |t|

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -55,6 +55,16 @@ ActiveRecord::Schema.define do
     t.timestamps                 :null => false
   end
 
+  create_table "double_entry_line_metadata", :force => true do |t|
+    t.integer    "line_id",               :null => false
+    t.string     "key",     :limit => 48, :null => false
+    t.string     "value",   :limit => 64, :null => false
+    t.timestamps                          :null => false
+  end
+
+  add_index "double_entry_line_metadata", ["key"]   :name => "lines_meta_key_idx"
+  add_index "double_entry_line_metadata", ["value"] :name => "lines_meta_value_idx"
+
   # test table only
   create_table "users", :force => true do |t|
     t.string     "username", :null => false

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -62,9 +62,7 @@ ActiveRecord::Schema.define do
     t.timestamps                          :null => false
   end
 
-  add_index "double_entry_line_metadata", ["line_id"], :name => "lines_meta_line_id_idx"
-  add_index "double_entry_line_metadata", ["key"],     :name => "lines_meta_key_idx"
-  add_index "double_entry_line_metadata", ["value"],   :name => "lines_meta_value_idx"
+  add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
 
   # test table only
   create_table "users", :force => true do |t|


### PR DESCRIPTION
We want to be able to report on specific segments of the transactions that we make, rather than everything that matches a given code/account. As an example, how many things did we sell vs how many things did we sell to people in Zimbabwe? (filter on `key=buyer_location` and `value=zimbabe` perhaps)

This is the first step in providing a way to filter these transfers out to get the desired results needed. One thing to be cautious of is the performance implications on larger systems.