### PR TITLE
Raise DoubleEntry::Locking::LockWaitTimeout for lock wait timeouts

### DIFF
--- a/lib/double_entry/locking.rb
+++ b/lib/double_entry/locking.rb
@@ -44,7 +44,7 @@ module DoubleEntry
 
     rescue ActiveRecord::StatementInvalid => exception
       if exception.message =~ /lock wait timeout/i
-        fail LockWaitTimeout
+        raise LockWaitTimeout
       else
         raise
       end

--- a/lib/double_entry/locking.rb
+++ b/lib/double_entry/locking.rb
@@ -41,6 +41,13 @@ module DoubleEntry
       else
         lock.perform_lock(&Proc.new)
       end
+
+    rescue ActiveRecord::StatementInvalid => exception
+      if exception.message =~ /lock wait timeout/i
+        fail LockWaitTimeout
+      else
+        raise
+      end
     end
 
     # Return the account balance record for the given account name if there's a
@@ -176,6 +183,10 @@ module DoubleEntry
 
     # Raised if things go horribly, horribly wrong. This should never happen.
     class LockDisaster < RuntimeError
+    end
+
+    # Raised if waiting for locks times out.
+    class LockWaitTimeout < RuntimeError
     end
   end
 end

--- a/spec/double_entry/locking_spec.rb
+++ b/spec/double_entry/locking_spec.rb
@@ -148,9 +148,7 @@ RSpec.describe DoubleEntry::Locking do
     end.to_not raise_error
   end
 
-
   context 'handling ActiveRecord::StatementInvalid errors' do
-
     context 'non lock wait timeout errors' do
       let(:error) { ActiveRecord::StatementInvalid.new('some other error') }
       before do

--- a/spec/double_entry/locking_spec.rb
+++ b/spec/double_entry/locking_spec.rb
@@ -148,6 +148,19 @@ RSpec.describe DoubleEntry::Locking do
     end.to_not raise_error
   end
 
+  context 'lock wait timeout' do
+    before do
+      allow(DoubleEntry::AccountBalance).to receive(:with_restart_on_deadlock).
+        and_raise(ActiveRecord::StatementInvalid, 'lock wait timeout')
+    end
+
+    it 'raises a LockWaitTimeout error on lock wait timeouts' do
+      expect do
+        DoubleEntry::Locking.lock_accounts(@account_d, @account_e) {}
+      end.to raise_error(DoubleEntry::Locking::LockWaitTimeout)
+    end
+  end
+
   # sqlite cannot handle these cases so they don't run when DB=sqlite
   describe 'concurrent locking', :unless => ENV['DB'] == 'sqlite' do
     it 'allows multiple threads to lock at the same time' do


### PR DESCRIPTION
Introduce a new error `DoubleEntry::Locking::LockWaitTimeout`, which would be raised instead of `ActiveRecord::StatementInvalid: Mysql2::Error: Lock wait timeout exceeded`.

This allows us to easily identify when DoubleEntry has had a lock wait timeout and to handle it however we'd like.

To do:
- [x] Is there something equivalent in PostgreSQL?  
  I've been doing some research, and the two errors below seem relevant

    `ERROR: canceling statement due to statement timeout` (not quite though, maybe this just needs its own special `DoubleEntry::Locking::StatementTimeout` instead?)

   `ERROR: canceling statement due to lock timeout`
