### PR TITLE
Ensure that range is specified when performing an aggregate function over lines

### DIFF
--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -44,7 +44,7 @@ module DoubleEntry
     #     :sum,
     #     :checking,
     #     :save,
-    #     :range  => time_range,
+    #     time_range,
     #     :filter => [
     #       :scope    => {
     #         :name      => :specific_transfer_amount,
@@ -62,8 +62,8 @@ module DoubleEntry
     # @param [Symbol] code The application specific code for the type of
     #   transfer to perform an aggregate calculation on. As specified in the
     #   transfer configuration.
-    # @option options :range [DoubleEntry::Reporting::TimeRange] Only include
-    #   transfers in the given time range in the calculation.
+    # @param [DoubleEntry::Reporting::TimeRange] Only include transfers in the
+    #   given time range in the calculation.
     # @option options :filter [Array<Hash<Symbol,Hash<Symbol,Object>>>]
     #   An array of custom filter to apply before performing the aggregate
     #   calculation. Filters can be either scope filters, where the name must be
@@ -78,8 +78,8 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate(function, account, code, options = {})
-      Aggregate.new(function, account, code, options).formatted_amount
+    def aggregate(function, account, code, range, options = {})
+      Aggregate.new(function, account, code, range, options).formatted_amount
     end
 
     # Perform an aggregate calculation on a set of transfers for an account

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -79,7 +79,7 @@ module DoubleEntry
     #   is not supported.
     #
     def aggregate(function, account, code, range, options = {})
-      Aggregate.new(function, account, code, range, options).formatted_amount
+      Aggregate.formatted_amount(function, account, code, range, options)
     end
 
     # Perform an aggregate calculation on a set of transfers for an account

--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -69,14 +69,9 @@ module DoubleEntry
           calculate_yearly_average
         else
           zero = formatted_amount(0)
+          range = MonthRange.new(:year => range.year, :month => month)
           result = (1..12).inject(zero) do |total, month|
-            total + Aggregate.new(
-              function,
-              account,
-              code,
-              MonthRange.new(:year => range.year, :month => month),
-              :filter => filter,
-            ).formatted_amount
+            total + Aggregate.new(function, account, code, range, :filter => filter).formatted_amount
           end
           result.is_a?(Money) ? result.cents : result
         end

--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -2,16 +2,15 @@
 module DoubleEntry
   module Reporting
     class Aggregate
-      attr_reader :function, :account, :code, :range, :options, :filter, :currency
+      attr_reader :function, :account, :code, :range, :filter, :currency
 
-      def initialize(function, account, code, options)
+      def initialize(function, account, code, range, options = {})
         @function = function.to_s
         fail AggregateFunctionNotSupported unless %w(sum count average).include?(@function)
 
         @account = account
         @code = code ? code.to_s : nil
-        @options = options
-        @range = options[:range]
+        @range = range
         @filter = options[:filter]
         @currency = DoubleEntry::Account.currency(account)
       end
@@ -75,7 +74,7 @@ module DoubleEntry
               function,
               account,
               code,
-              :range => MonthRange.new(:year => range.year, :month => month),
+              MonthRange.new(:year => range.year, :month => month),
               :filter => filter,
             )
           end
@@ -86,8 +85,8 @@ module DoubleEntry
       def calculate_yearly_average
         # need this seperate function, because an average of averages is not the correct average
         year_range = YearRange.new(:year => range.year)
-        sum = Reporting.aggregate(:sum, account, code, :range => year_range, :filter => filter)
-        count = Reporting.aggregate(:count, account, code, :range => year_range, :filter => filter)
+        sum = Reporting.aggregate(:sum, account, code, year_range, :filter => filter)
+        count = Reporting.aggregate(:count, account, code, year_range, :filter => filter)
         (count == 0) ? 0 : (sum / count).cents
       end
 

--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -68,10 +68,8 @@ module DoubleEntry
         if function == 'average'
           calculate_yearly_average
         else
-          zero = formatted_amount(0)
-          range = MonthRange.new(:year => range.year, :month => month)
-          result = (1..12).inject(zero) do |total, month|
-            total + Aggregate.new(function, account, code, range, :filter => filter).formatted_amount
+          result = (1..12).inject(formatted_amount(0)) do |total, month|
+            total + Aggregate.new(function, account, code, MonthRange.new(:year => range.year, :month => month), :filter => filter).formatted_amount
           end
           result.is_a?(Money) ? result.cents : result
         end

--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -70,13 +70,13 @@ module DoubleEntry
         else
           zero = formatted_amount(0)
           result = (1..12).inject(zero) do |total, month|
-            total + Reporting.aggregate(
+            total + Aggregate.new(
               function,
               account,
               code,
               MonthRange.new(:year => range.year, :month => month),
               :filter => filter,
-            )
+            ).formatted_amount
           end
           result.is_a?(Money) ? result.cents : result
         end
@@ -85,8 +85,8 @@ module DoubleEntry
       def calculate_yearly_average
         # need this seperate function, because an average of averages is not the correct average
         year_range = YearRange.new(:year => range.year)
-        sum = Reporting.aggregate(:sum, account, code, year_range, :filter => filter)
-        count = Reporting.aggregate(:count, account, code, year_range, :filter => filter)
+        sum = Aggregate.new(:sum, account, code, year_range, :filter => filter).formatted_amount
+        count = Aggregate.new(:count, account, code, year_range, :filter => filter).formatted_amount
         (count == 0) ? 0 : (sum / count).cents
       end
 

--- a/lib/double_entry/reporting/aggregate.rb
+++ b/lib/double_entry/reporting/aggregate.rb
@@ -4,6 +4,10 @@ module DoubleEntry
     class Aggregate
       attr_reader :function, :account, :code, :range, :filter, :currency
 
+      def self.formatted_amount(function, account, code, range, options = {})
+        new(function, account, code, range, options).formatted_amount
+      end
+
       def initialize(function, account, code, range, options = {})
         @function = function.to_s
         fail AggregateFunctionNotSupported unless %w(sum count average).include?(@function)

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -39,7 +39,7 @@ module DoubleEntry
         # (this includes aggregates for the still-running period)
         all_periods.each do |period|
           unless @aggregates[period.key]
-            @aggregates[period.key] = Reporting.aggregate(function, account, code, :filter => filter, :range => period)
+            @aggregates[period.key] = Reporting.aggregate(function, account, code, period, :filter => filter)
           end
         end
       end

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -39,7 +39,7 @@ module DoubleEntry
         # (this includes aggregates for the still-running period)
         all_periods.each do |period|
           unless @aggregates[period.key]
-            @aggregates[period.key] = Reporting.aggregate(function, account, code, period, :filter => filter)
+            @aggregates[period.key] = Aggregate.formatted_amount(function, account, code, period, :filter => filter)
           end
         end
       end

--- a/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
+++ b/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
@@ -23,8 +23,7 @@ module DoubleEntry
           start_profiling
           # TODO: aggregate with metadata filter
           Reporting.aggregate(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2015, :month => 06, :range_type => :all_time)
+            :sum, :savings, :bonus, TimeRange.make(:year => 2015, :month => 06, :range_type => :all_time)
           )
           result = stop_profiling('aggregate')
           expect(total_time(result)).to be_faster_than(:local => 0.610, :ci => 0.800)

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -5,11 +5,11 @@ module DoubleEntry
       let(:start) { nil }
       let(:finish) { nil }
       let(:range_type) { 'year' }
-      let(:function) { :sum }
+      let(:function) { 'sum' }
       let(:account) { :savings }
       let(:transfer_code) { :bonus }
       subject(:aggregate_array) do
-        Reporting.aggregate_array(
+        AggregateArray.new(
           function,
           account,
           transfer_code,
@@ -42,17 +42,17 @@ module DoubleEntry
 
               context 'and some aggregates were created previously' do
                 before do
-                  Reporting.aggregate(function.to_s, account, transfer_code, years[0])
-                  Reporting.aggregate(function.to_s, account, transfer_code, years[1])
-                  allow(Reporting).to receive(:aggregate)
+                  Aggregate.formatted_amount(function, account, transfer_code, years[0])
+                  Aggregate.formatted_amount(function, account, transfer_code, years[1])
+                  allow(Aggregate).to receive(:formatted_amount)
                 end
 
-                it 'only asks Reporting for the non-existent ones' do
-                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, years[0], :filter => nil)
-                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, years[1], :filter => nil)
+                it 'only asks Aggregate for the non-existent ones' do
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], :filter => nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], :filter => nil)
 
-                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, years[2], :filter => nil)
-                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, years[3], :filter => nil)
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], :filter => nil)
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], :filter => nil)
                   aggregate_array
                 end
               end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -42,17 +42,17 @@ module DoubleEntry
 
               context 'and some aggregates were created previously' do
                 before do
-                  Reporting.aggregate(function.to_s, account, transfer_code, :filter => nil, :range => years[0])
-                  Reporting.aggregate(function.to_s, account, transfer_code, :filter => nil, :range => years[1])
+                  Reporting.aggregate(function.to_s, account, transfer_code, years[0])
+                  Reporting.aggregate(function.to_s, account, transfer_code, years[1])
                   allow(Reporting).to receive(:aggregate)
                 end
 
                 it 'only asks Reporting for the non-existent ones' do
-                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[0])
-                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[1])
+                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, years[0], :filter => nil)
+                  expect(Reporting).not_to receive(:aggregate).with(function.to_s, account, transfer_code, years[1], :filter => nil)
 
-                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[2])
-                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, :filter => nil, :range => years[3])
+                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, years[2], :filter => nil)
+                  expect(Reporting).to receive(:aggregate).with(function.to_s, account, transfer_code, years[3], :filter => nil)
                   aggregate_array
                 end
               end

--- a/spec/double_entry/reporting/aggregate_spec.rb
+++ b/spec/double_entry/reporting/aggregate_spec.rb
@@ -45,126 +45,82 @@ module DoubleEntry
       end
 
       it 'should calculate the complete year correctly' do
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009)
-          ).formatted_amount
-        ).to eq Money.new(200_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009)).formatted_amount
+        expect(amount).to eq Money.new(200_00)
       end
 
       it 'should calculate seperate months correctly' do
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)
-          ).formatted_amount
-        ).to eq Money.new(110_00)
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)
-          ).formatted_amount
-        ).to eq Money.new(90_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).formatted_amount
+        expect(amount).to eq Money.new(110_00)
+
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)).formatted_amount
+        expect(amount).to eq Money.new(90_00)
       end
 
       it 'should calculate seperate weeks correctly' do
         # Week 40 - Mon Sep 28, 2009 to Sun Oct 4 2009
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 40)
-          ).formatted_amount
-        ).to eq Money.new(60_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 40)).formatted_amount
+        expect(amount).to eq Money.new(60_00)
       end
 
       it 'should calculate seperate days correctly' do
         # 1 Nov 2009
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7)
-          ).formatted_amount
-        ).to eq Money.new(90_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7)).formatted_amount
+        expect(amount).to eq Money.new(90_00)
       end
 
       it 'should calculate seperate hours correctly' do
         # 1 Nov 2009
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)
-          ).formatted_amount
-        ).to eq Money.new(40_00)
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)
-          ).formatted_amount
-        ).to eq Money.new(50_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)).formatted_amount
+        expect(amount).to eq Money.new(40_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)).formatted_amount
+        expect(amount).to eq Money.new(50_00)
       end
 
       it 'should calculate, but not store aggregates when the time range is still current' do
         Timecop.freeze Time.local(2009, 11, 21) do
-          expect(
-            Aggregate.new(
-              :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)
-            ).formatted_amount
-          ).to eq Money.new(90_00)
+          amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)).formatted_amount
+          expect(amount).to eq Money.new(90_00)
           expect(LineAggregate.count).to eq 0
         end
       end
 
       it 'should calculate, but not store aggregates when the time range is in the future' do
         Timecop.freeze Time.local(2009, 11, 21) do
-          expect(
-            Aggregate.new(
-              :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12)
-            ).formatted_amount
-          ).to eq Money.new(0)
+          amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12)).formatted_amount
+          expect(amount).to eq Money.new(0)
           expect(LineAggregate.count).to eq 0
         end
       end
 
       it 'should calculate monthly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq Money.new(200_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq Money.new(200_00)
       end
 
       it 'calculates the average monthly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :average, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq expected_monthly_average
+        amount = Aggregate.new(:average, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq expected_monthly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :count, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq 5
+        amount = Aggregate.new(:count, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq 5
       end
 
       it 'should calculate weekly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq Money.new(110_00)
+        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq Money.new(110_00)
       end
 
       it 'calculates the average weekly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :average, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq expected_weekly_average
+        amount = Aggregate.new(:average, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq expected_weekly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
-        expect(
-          Aggregate.new(
-            :count, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount
-        ).to eq 3
+        amount = Aggregate.new(:count, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        expect(amount).to eq 3
       end
 
       it 'raises an AggregateFunctionNotSupported exception' do
@@ -225,12 +181,11 @@ module DoubleEntry
           Aggregate.new(:sum, :savings, :bonus, range).amount
 
           # ensure a second call loads the correct cached value
-          expect(
-            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).formatted_amount
-          ).to eq Money.new(10_00)
-          expect(
-            Aggregate.new(:sum, :savings, :bonus, range).formatted_amount
-          ).to eq Money.new(19_00)
+          amount = Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).formatted_amount
+          expect(amount).to eq Money.new(10_00)
+
+          amount = Aggregate.new(:sum, :savings, :bonus, range).formatted_amount
+          expect(amount).to eq Money.new(19_00)
         end
       end
     end
@@ -242,11 +197,8 @@ module DoubleEntry
       end
 
       it 'should calculate the sum in the correct currency' do
-        expect(
-          Aggregate.new(
-            :sum, :btc_savings, :btc_test_transfer, TimeRange.make(:year => Time.now.year)
-          ).formatted_amount
-        ).to eq(Money.new(300_000_000, :btc))
+        amount = Aggregate.new(:sum, :btc_savings, :btc_test_transfer, TimeRange.make(:year => Time.now.year)).formatted_amount
+        expect(amount).to eq(Money.new(300_000_000, :btc))
       end
     end
   end

--- a/spec/double_entry/reporting/aggregate_spec.rb
+++ b/spec/double_entry/reporting/aggregate_spec.rb
@@ -9,13 +9,6 @@ module DoubleEntry
       let(:expected_monthly_average) do
         (Money.new(20_00) + Money.new(40_00) + Money.new(50_00) + Money.new(40_00) + Money.new(50_00)) / 5
       end
-      let(:filter) do
-        [
-          :scope => {
-            :name => :test_filter,
-          },
-        ]
-      end
 
       before do
         # Thursday
@@ -40,38 +33,35 @@ module DoubleEntry
       end
 
       it 'should store the aggregate for quick retrieval' do
-        Aggregate.new(:sum, :savings, :bonus, :range => TimeRange.make(:year => 2009, :month => 10)).amount
+        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).amount
         expect(LineAggregate.count).to eq 1
       end
 
       it 'should only store the aggregate once if it is requested more than once' do
-        Aggregate.new(:sum, :savings, :bonus, :range => TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(:sum, :savings, :bonus, :range => TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(:sum, :savings, :bonus, :range => TimeRange.make(:year => 2009, :month => 10)).amount
+        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).amount
         expect(LineAggregate.count).to eq 2
       end
 
       it 'should calculate the complete year correctly' do
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009)
+          ).formatted_amount
         ).to eq Money.new(200_00)
       end
 
       it 'should calculate seperate months correctly' do
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :month => 10)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)
+          ).formatted_amount
         ).to eq Money.new(110_00)
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :month => 11)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)
+          ).formatted_amount
         ).to eq Money.new(90_00)
       end
 
@@ -79,9 +69,8 @@ module DoubleEntry
         # Week 40 - Mon Sep 28, 2009 to Sun Oct 4 2009
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 40)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 40)
+          ).formatted_amount
         ).to eq Money.new(60_00)
       end
 
@@ -89,9 +78,8 @@ module DoubleEntry
         # 1 Nov 2009
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 44, :day => 7)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7)
+          ).formatted_amount
         ).to eq Money.new(90_00)
       end
 
@@ -99,15 +87,13 @@ module DoubleEntry
         # 1 Nov 2009
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)
+          ).formatted_amount
         ).to eq Money.new(40_00)
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)
+          ).formatted_amount
         ).to eq Money.new(50_00)
       end
 
@@ -115,9 +101,8 @@ module DoubleEntry
         Timecop.freeze Time.local(2009, 11, 21) do
           expect(
             Aggregate.new(
-              :sum, :savings, :bonus,
-              :range => TimeRange.make(:year => 2009, :month => 11)
-            ).formatted_amount,
+              :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)
+            ).formatted_amount
           ).to eq Money.new(90_00)
           expect(LineAggregate.count).to eq 0
         end
@@ -127,9 +112,8 @@ module DoubleEntry
         Timecop.freeze Time.local(2009, 11, 21) do
           expect(
             Aggregate.new(
-              :sum, :savings, :bonus,
-              :range => TimeRange.make(:year => 2009, :month => 12)
-            ).formatted_amount,
+              :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12)
+            ).formatted_amount
           ).to eq Money.new(0)
           expect(LineAggregate.count).to eq 0
         end
@@ -138,68 +122,68 @@ module DoubleEntry
       it 'should calculate monthly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
+          ).formatted_amount
         ).to eq Money.new(200_00)
       end
 
       it 'calculates the average monthly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :average, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount,
+            :average, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
+          ).formatted_amount
         ).to eq expected_monthly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :count, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
-          ).formatted_amount,
+            :count, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)
+          ).formatted_amount
         ).to eq 5
       end
 
       it 'should calculate weekly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :sum, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount,
+            :sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
+          ).formatted_amount
         ).to eq Money.new(110_00)
       end
 
       it 'calculates the average weekly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :average, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount,
+            :average, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
+          ).formatted_amount
         ).to eq expected_weekly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
         expect(
           Aggregate.new(
-            :count, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
-          ).formatted_amount,
+            :count, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
+          ).formatted_amount
         ).to eq 3
       end
 
       it 'raises an AggregateFunctionNotSupported exception' do
         expect do
           Aggregate.new(
-            :not_supported_calculation, :savings, :bonus,
-            :range => TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
+            :not_supported_calculation, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
           ).amount
         end.to raise_error(AggregateFunctionNotSupported)
       end
 
       context 'filters' do
         let(:range) { TimeRange.make(:year => 2011, :month => 10) }
+        let(:filter) do
+          [
+            :scope => {
+              :name => :test_filter,
+            },
+          ]
+        end
 
         DoubleEntry::Line.class_eval do
           scope :test_filter, -> { where(:amount => 10_00) }
@@ -217,35 +201,35 @@ module DoubleEntry
 
         it 'saves filtered aggregations' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, :range => range, :filter => filter).amount
+            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
           end.to change { LineAggregate.count }.by 1
         end
 
         it 'saves filtered aggregation only once for a range' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, :range => range, :filter => filter).amount
-            Aggregate.new(:sum, :savings, :bonus, :range => range, :filter => filter).amount
+            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
+            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
           end.to change { LineAggregate.count }.by 1
         end
 
         it 'saves filtered aggregations and non filtered aggregations separately' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, :range => range, :filter => filter).amount
-            Aggregate.new(:sum, :savings, :bonus, :range => range).amount
+            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
+            Aggregate.new(:sum, :savings, :bonus, range).amount
           end.to change { LineAggregate.count }.by 2
         end
 
         it 'loads the correct saved aggregation' do
           # cache the results for filtered and unfiltered aggregations
-          Aggregate.new(:sum, :savings, :bonus, :range => range, :filter => filter).amount
-          Aggregate.new(:sum, :savings, :bonus, :range => range).amount
+          Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
+          Aggregate.new(:sum, :savings, :bonus, range).amount
 
           # ensure a second call loads the correct cached value
           expect(
-            Aggregate.new(:sum, :savings, :bonus, :range  => range, :filter => filter).formatted_amount,
+            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).formatted_amount
           ).to eq Money.new(10_00)
           expect(
-            Aggregate.new(:sum, :savings, :bonus, :range  => range).formatted_amount,
+            Aggregate.new(:sum, :savings, :bonus, range).formatted_amount
           ).to eq Money.new(19_00)
         end
       end
@@ -260,8 +244,8 @@ module DoubleEntry
       it 'should calculate the sum in the correct currency' do
         expect(
           Aggregate.new(
-            :sum, :btc_savings, :btc_test_transfer, :range => TimeRange.make(:year => Time.now.year)
-          ).formatted_amount,
+            :sum, :btc_savings, :btc_test_transfer, TimeRange.make(:year => Time.now.year)
+          ).formatted_amount
         ).to eq(Money.new(300_000_000, :btc))
       end
     end

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe DoubleEntry::Reporting do
   describe '::aggregate' do
     before do
       # get rid of "helpful" predefined config
-      @config_accounts = DoubleEntry.configuration.accounts
+      @config_accounts  = DoubleEntry.configuration.accounts
       @config_transfers = DoubleEntry.configuration.transfers
-      DoubleEntry.configuration.accounts = DoubleEntry::Account::Set.new
+      DoubleEntry.configuration.accounts  = DoubleEntry::Account::Set.new
       DoubleEntry.configuration.transfers = DoubleEntry::Transfer::Set.new
 
       DoubleEntry.configure do |config|
@@ -77,9 +77,9 @@ RSpec.describe DoubleEntry::Reporting do
       DoubleEntry.transfer(Money.new(50_00), :from => savings, :to => cash,    :code => :spend)
       DoubleEntry.transfer(Money.new(60_00), :from => savings, :to => cash,    :code => :spend)
 
-      first_transfer         = DoubleEntry::Line.all[0]
-      second_transfer        = DoubleEntry::Line.all[2]
-      last_transfer          = DoubleEntry::Line.all[14]
+      first_transfer  = DoubleEntry::Line.all[0]
+      second_transfer = DoubleEntry::Line.all[2]
+      last_transfer   = DoubleEntry::Line.all[14]
       DoubleEntry::LineMetadata.create!(:line => first_transfer,          :key => :reason,   :value => :payday)
       DoubleEntry::LineMetadata.create!(:line => first_transfer.partner,  :key => :reason,   :value => :payday)
       DoubleEntry::LineMetadata.create!(:line => second_transfer,         :key => :reason,   :value => :payday)
@@ -90,7 +90,7 @@ RSpec.describe DoubleEntry::Reporting do
 
     after do
       # restore "helpful" predefined config
-      DoubleEntry.configuration.accounts = @config_accounts
+      DoubleEntry.configuration.accounts  = @config_accounts
       DoubleEntry.configuration.transfers = @config_transfers
     end
 
@@ -101,7 +101,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, :range => range)
+        DoubleEntry::Reporting.aggregate(function, account, code, range)
       end
 
       specify 'Total attempted to save' do
@@ -117,8 +117,7 @@ RSpec.describe DoubleEntry::Reporting do
 
       subject(:aggregate) do
         DoubleEntry::Reporting.aggregate(
-          function, account, code,
-          :range  => range,
+          function, account, code, range,
           :filter => [
             :scope => {
               :name => :ten_dollar_transfers,
@@ -146,8 +145,7 @@ RSpec.describe DoubleEntry::Reporting do
 
       subject(:aggregate) do
         DoubleEntry::Reporting.aggregate(
-          function, account, code,
-          :range  => range,
+          function, account, code, range,
           :filter => [
             :scope => {
               :name      => :specific_transfer_amount,
@@ -176,8 +174,7 @@ RSpec.describe DoubleEntry::Reporting do
 
       subject(:aggregate) do
         DoubleEntry::Reporting.aggregate(
-          function, account, code,
-          :range  => range,
+          function, account, code, range,
           :filter => [
             :metadata => {
               :reason => :payday,


### PR DESCRIPTION
Currently, we are able to perform an aggregation without specifying a range value (Hash Magic). This is not a case that is gracefully handled, and when done, will result in a rather ungraceful explosion. Lets ensure that range is a required argument so that we can safely aggregate