### PR TITLE
Allow partner_account to be specified for aggregates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ script:
   - ruby script/jack_hammer -t 2000
 matrix:
   include:
-    - rvm: 2.0.0
-      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
-      env: DB=mysql
     - rvm: 2.1.7
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ DoubleEntry uses the [Money gem](https://github.com/RubyMoney/money) to encapsul
 DoubleEntry is tested against:
 
 Ruby
- * 2.0.0
  * 2.1.5
  * 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DoubleEntry uses the [Money gem](https://github.com/RubyMoney/money) to encapsul
 DoubleEntry is tested against:
 
 Ruby
- * 2.1.5
+ * 2.1.7
  * 2.2.0
 
 Rails

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -78,8 +78,8 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate(function, account, code, range, filter: nil, partner_account: nil)
-      Aggregate.formatted_amount(function, account, code, range, filter: filter, partner_account: partner_account)
+    def aggregate(function, account, code, range, partner_account: nil, filter: nil)
+      Aggregate.formatted_amount(function, account, code, range, partner_account: partner_account, filter: filter)
     end
 
     # Perform an aggregate calculation on a set of transfers for an account
@@ -128,10 +128,10 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate_array(function, account, code, filter: nil, range_type: nil, start: nil, finish: nil,
-                     partner_account: nil)
-      AggregateArray.new(function, account, code, filter: filter, range_type: range_type, start: start, finish: finish,
-                         partner_account: partner_account)
+    def aggregate_array(function, account, code, partner_account: nil, filter: nil,
+                        range_type: nil, start: nil, finish: nil)
+      AggregateArray.new(function, account, code, partner_account: partner_account,
+                         filter: filter, range_type: range_type, start: start, finish: finish)
     end
 
     # Identify the scopes with the given account identifier holding at least

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -62,9 +62,12 @@ module DoubleEntry
     # @param [Symbol] code The application specific code for the type of
     #   transfer to perform an aggregate calculation on. As specified in the
     #   transfer configuration.
-    # @param [DoubleEntry::Reporting::TimeRange] Only include transfers in the
-    #   given time range in the calculation.
-    # @option options :filter [Array<Hash<Symbol,Hash<Symbol,Object>>>]
+    # @param [DoubleEntry::Reporting::TimeRange] range Only include transfers in
+    #   the given time range in the calculation.
+    # @param [Symbol] partner_account The symbol identifying the partner account
+    #   to perform the aggregate calculatoin on.  As specified in the account
+    #   configuration.
+    # @param [Array<Hash<Symbol,Hash<Symbol,Object>>>] filter
     #   An array of custom filter to apply before performing the aggregate
     #   calculation. Filters can be either scope filters, where the name must be
     #   specified, or they can be metadata filters, where the key/value pair to
@@ -104,21 +107,24 @@ module DoubleEntry
     # @param [Symbol] code The application specific code for the type of
     #   transfer to perform an aggregate calculation on. As specified in the
     #   transfer configuration.
-    # @option options :filter [Array<Symbol>, Array<Hash<Symbol, Object>>]
+    # @param [Symbol] partner_account The symbol identifying the partner account
+    #   to perform the aggregative calculation on.  As specified in the account
+    #   configuration.
+    # @param [Array<Symbol>, Array<Hash<Symbol, Object>>] filter
     #   A custom filter to apply before performing the aggregate calculation.
     #   Currently, filters must be monkey patched as scopes into the
     #   DoubleEntry::Line class in order to be used as filters, as the example
     #   shows. If the filter requires a parameter, it must be given in a Hash,
     #   otherwise pass an array with the symbol names for the defined scopes.
-    # @option options :range_type [String] The type of time range to return data
-    #   for.  For example, specifying 'month' will return an array of the resulting
+    # @param [String] range_type The type of time range to return data
+    #   for. For example, specifying 'month' will return an array of the resulting
     #   aggregate calculation for each month.
     #   Valid range_types are 'hour', 'day', 'week', 'month', and 'year'
-    # @option options :start [String] The start date for the time range to perform
+    # @param [String] start The start date for the time range to perform
     #   calculations in.  The default start date is the start_of_business (can
     #   be specified in configuration).
     #   The format of the string must be as follows: 'YYYY-mm-dd'
-    # @option options :finish [String] The finish (or end) date for the time range
+    # @param [String] finish The finish (or end) date for the time range
     #   to perform calculations in.  The default finish date is the current date.
     #   The format of the string must be as follows: 'YYYY-mm-dd'
     # @return [Array<Money, Fixnum>] Returns an array of Money objects for :sum

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -78,8 +78,8 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate(function, account, code, range, options = {})
-      Aggregate.formatted_amount(function, account, code, range, options)
+    def aggregate(function, account, code, range, filter: nil, partner_account: nil)
+      Aggregate.formatted_amount(function, account, code, range, filter: filter, partner_account: partner_account)
     end
 
     # Perform an aggregate calculation on a set of transfers for an account
@@ -128,8 +128,10 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate_array(function, account, code, options = {})
-      AggregateArray.new(function, account, code, options)
+    def aggregate_array(function, account, code, filter: nil, range_type: nil, start: nil, finish: nil,
+                     partner_account: nil)
+      AggregateArray.new(function, account, code, filter: filter, range_type: range_type, start: start, finish: finish,
+                         partner_account: partner_account)
     end
 
     # Identify the scopes with the given account identifier holding at least

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -137,7 +137,7 @@ module DoubleEntry
     #
     def aggregate_array(function:, account:, code:, partner_account: nil, filter: nil,
                         range_type: nil, start: nil, finish: nil)
-      AggregateArray.new(function: function, account: account, code:  code, partner_account: partner_account,
+      AggregateArray.new(function: function, account: account, code: code, partner_account: partner_account,
                          filter: filter, range_type: range_type, start: start, finish: finish)
     end
 

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -81,8 +81,9 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate(function, account, code, range, partner_account: nil, filter: nil)
-      Aggregate.formatted_amount(function, account, code, range, partner_account: partner_account, filter: filter)
+    def aggregate(function:, account:, code:, range:, partner_account: nil, filter: nil)
+      Aggregate.formatted_amount(function: function, account: account, code: code, range: range,
+                                 partner_account: partner_account, filter: filter)
     end
 
     # Perform an aggregate calculation on a set of transfers for an account
@@ -134,9 +135,9 @@ module DoubleEntry
     # @raise [Reporting::AggregateFunctionNotSupported] The provided function
     #   is not supported.
     #
-    def aggregate_array(function, account, code, partner_account: nil, filter: nil,
+    def aggregate_array(function:, account:, code:, partner_account: nil, filter: nil,
                         range_type: nil, start: nil, finish: nil)
-      AggregateArray.new(function, account, code, partner_account: partner_account,
+      AggregateArray.new(function: function, account: account, code:  code, partner_account: partner_account,
                          filter: filter, range_type: range_type, start: start, finish: finish)
     end
 

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -11,7 +11,7 @@ module DoubleEntry
       # broken down by month and it would return an array of values
       attr_reader :function, :account, :partner_account, :code, :filter, :range_type, :start, :finish, :currency
 
-      def initialize(function, account, code, partner_account: nil, filter: nil, range_type: nil, start: nil, finish: nil)
+      def initialize(function:, account:, code:, partner_account: nil, filter: nil, range_type: nil, start: nil, finish: nil)
         @function        = function.to_s
         @account         = account
         @code            = code
@@ -40,8 +40,8 @@ module DoubleEntry
         # (this includes aggregates for the still-running period)
         all_periods.each do |period|
           unless @aggregates[period.key]
-            @aggregates[period.key] = Aggregate.formatted_amount(function, account, code, period,
-                                                                 partner_account: partner_account, filter: filter)
+            @aggregates[period.key] = Aggregate.formatted_amount(function: function, account: account, code: code,
+                                                                 range: period, partner_account: partner_account, filter: filter)
           end
         end
       end

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -9,18 +9,17 @@ module DoubleEntry
       #
       # For example, you could request all sales
       # broken down by month and it would return an array of values
-      attr_reader :function, :account, :code, :partner_account, :filter, :range_type, :start, :finish, :currency
+      attr_reader :function, :account, :partner_account, :code, :filter, :range_type, :start, :finish, :currency
 
-      def initialize(function, account, code, filter: nil, range_type: nil, start: nil, finish: nil,
-                     partner_account: nil)
+      def initialize(function, account, code, partner_account: nil, filter: nil, range_type: nil, start: nil, finish: nil)
         @function        = function.to_s
         @account         = account
         @code            = code
+        @partner_account = partner_account
         @filter          = filter
         @range_type      = range_type
         @start           = start
         @finish          = finish
-        @partner_account = partner_account
         @currency        = DoubleEntry::Account.currency(account)
 
         retrieve_aggregates
@@ -42,7 +41,7 @@ module DoubleEntry
         all_periods.each do |period|
           unless @aggregates[period.key]
             @aggregates[period.key] = Aggregate.formatted_amount(function, account, code, period,
-                                                                 filter: filter, partner_account: partner_account)
+                                                                 partner_account: partner_account, filter: filter)
           end
         end
       end
@@ -54,8 +53,8 @@ module DoubleEntry
                 where(:function => function).
                 where(:range_type => 'normal').
                 where(:account => account.try(:to_s)).
-                where(:code => code.try(:to_s)).
                 where(:partner_account => partner_account.try(:to_s)).
+                where(:code => code.try(:to_s)).
                 where(:filter => filter.inspect).
                 where(LineAggregate.arel_table[range_type].not_eq(nil))
         @aggregates = scope.each_with_object({}) do |result, hash|

--- a/lib/double_entry/reporting/aggregate_array.rb
+++ b/lib/double_entry/reporting/aggregate_array.rb
@@ -53,8 +53,8 @@ module DoubleEntry
         scope = LineAggregate.
                 where(:function => function).
                 where(:range_type => 'normal').
-                where(:account => account.to_s).
-                where(:code => code.to_s).
+                where(:account => account.try(:to_s)).
+                where(:code => code.try(:to_s)).
                 where(:partner_account => partner_account.try(:to_s)).
                 where(:filter => filter.inspect).
                 where(LineAggregate.arel_table[range_type].not_eq(nil))

--- a/lib/double_entry/reporting/line_aggregate.rb
+++ b/lib/double_entry/reporting/line_aggregate.rb
@@ -2,8 +2,9 @@
 module DoubleEntry
   module Reporting
     class LineAggregate < ActiveRecord::Base
-      def self.aggregate(function, account, partner_account, code, range, named_scopes)
-        collection_filter = LineAggregateFilter.new(account, partner_account, code, range, named_scopes)
+      def self.aggregate(function:, account:, partner_account:, code:, range:, named_scopes:)
+        collection_filter = LineAggregateFilter.new(account: account, partner_account: partner_account,
+                                                    code: code, range: range, filter_criteria: named_scopes)
         collection = collection_filter.filter
         collection.send(function, :amount)
       end

--- a/lib/double_entry/reporting/line_aggregate.rb
+++ b/lib/double_entry/reporting/line_aggregate.rb
@@ -2,8 +2,8 @@
 module DoubleEntry
   module Reporting
     class LineAggregate < ActiveRecord::Base
-      def self.aggregate(function, account, code, range, named_scopes, partner_account)
-        collection_filter = LineAggregateFilter.new(account, code, range, named_scopes, partner_account)
+      def self.aggregate(function, account, partner_account, code, range, named_scopes)
+        collection_filter = LineAggregateFilter.new(account, partner_account, code, range, named_scopes)
         collection = collection_filter.filter
         collection.send(function, :amount)
       end

--- a/lib/double_entry/reporting/line_aggregate.rb
+++ b/lib/double_entry/reporting/line_aggregate.rb
@@ -2,8 +2,8 @@
 module DoubleEntry
   module Reporting
     class LineAggregate < ActiveRecord::Base
-      def self.aggregate(function, account, code, range, named_scopes)
-        collection_filter = LineAggregateFilter.new(account, code, range, named_scopes)
+      def self.aggregate(function, account, code, range, named_scopes, partner_account)
+        collection_filter = LineAggregateFilter.new(account, code, range, named_scopes, partner_account)
         collection = collection_filter.filter
         collection.send(function, :amount)
       end

--- a/lib/double_entry/reporting/line_aggregate_filter.rb
+++ b/lib/double_entry/reporting/line_aggregate_filter.rb
@@ -2,7 +2,7 @@
 module DoubleEntry
   module Reporting
     class LineAggregateFilter
-      def initialize(account, partner_account, code, range, filter_criteria)
+      def initialize(account:, partner_account:, code:, range:, filter_criteria:)
         @account         = account
         @partner_account = partner_account
         @code            = code

--- a/lib/double_entry/reporting/line_aggregate_filter.rb
+++ b/lib/double_entry/reporting/line_aggregate_filter.rb
@@ -2,12 +2,12 @@
 module DoubleEntry
   module Reporting
     class LineAggregateFilter
-      def initialize(account, code, range, filter_criteria, partner_account)
+      def initialize(account, partner_account, code, range, filter_criteria)
         @account         = account
+        @partner_account = partner_account
         @code            = code
         @range           = range
         @filter_criteria = filter_criteria || []
-        @partner_account = partner_account
       end
 
       def filter

--- a/lib/double_entry/reporting/line_aggregate_filter.rb
+++ b/lib/double_entry/reporting/line_aggregate_filter.rb
@@ -2,11 +2,12 @@
 module DoubleEntry
   module Reporting
     class LineAggregateFilter
-      def initialize(account, code, range, filter_criteria)
+      def initialize(account, code, range, filter_criteria, partner_account)
         @account         = account
         @code            = code
         @range           = range
         @filter_criteria = filter_criteria || []
+        @partner_account = partner_account
       end
 
       def filter
@@ -20,6 +21,7 @@ module DoubleEntry
                      where(:account => @account).
                      where(:created_at => @range.start..@range.finish)
         collection = collection.where(:code => @code) if @code
+        collection = collection.where(:partner_account => @partner_account) if @partner_account
 
         collection
       end

--- a/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
+++ b/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
@@ -39,9 +39,7 @@ module DoubleEntry
       def profile_aggregation_with_filter(filter)
         start_profiling
         range = TimeRange.make(:year   => 2015, :month => 06, :range_type => :all_time)
-        options = {}
-        options[:filter] = filter if filter
-        Reporting.aggregate(:sum, :savings, :bonus, range, options)
+        Reporting.aggregate(:sum, :savings, :bonus, range, filter: filter)
         profile_name = filter ? 'aggregate-with-metadata' : 'aggregate'
         stop_profiling(profile_name)
       end

--- a/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
+++ b/spec/double_entry/performance/reporting/aggregate_performance_spec.rb
@@ -39,7 +39,7 @@ module DoubleEntry
       def profile_aggregation_with_filter(filter)
         start_profiling
         range = TimeRange.make(:year   => 2015, :month => 06, :range_type => :all_time)
-        Reporting.aggregate(:sum, :savings, :bonus, range, filter: filter)
+        Reporting.aggregate(function: :sum, account: :savings, code: :bonus, range: range, filter: filter)
         profile_name = filter ? 'aggregate-with-metadata' : 'aggregate'
         stop_profiling(profile_name)
       end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -9,14 +9,7 @@ module DoubleEntry
       let(:account) { :savings }
       let(:transfer_code) { :bonus }
       subject(:aggregate_array) do
-        AggregateArray.new(
-          function,
-          account,
-          transfer_code,
-          :range_type => range_type,
-          :start => start,
-          :finish => finish,
-        )
+        AggregateArray.new(function, account, transfer_code, range_type: range_type, start: start, finish: finish)
       end
 
       context 'given a deposit was made in 2007 and 2008' do
@@ -50,11 +43,15 @@ module DoubleEntry
                 let(:transfer_code) { nil }
 
                 it 'only asks Aggregate for the non-existent ones' do
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], filter: nil, partner_account: nil)
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], filter: nil, partner_account: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
 
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], filter: nil, partner_account: nil)
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], filter: nil, partner_account: nil)
+                  expect(Aggregate).to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
+                  expect(Aggregate).to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
                   aggregate_array
                 end
               end
@@ -63,11 +60,15 @@ module DoubleEntry
                 let(:transfer_code) { :bonus }
 
                 it 'only asks Aggregate for the non-existent ones' do
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], filter: nil, partner_account: nil)
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], filter: nil, partner_account: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
 
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], filter: nil, partner_account: nil)
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], filter: nil, partner_account: nil)
+                  expect(Aggregate).to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
+                  expect(Aggregate).to receive(:formatted_amount).
+                    with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
                   aggregate_array
                 end
               end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -48,11 +48,11 @@ module DoubleEntry
                 end
 
                 it 'only asks Aggregate for the non-existent ones' do
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], :filter => nil)
-                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], :filter => nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], filter: nil, partner_account: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], filter: nil, partner_account: nil)
 
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], :filter => nil)
-                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], :filter => nil)
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], filter: nil, partner_account: nil)
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], filter: nil, partner_account: nil)
                   aggregate_array
                 end
               end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -40,12 +40,27 @@ module DoubleEntry
             describe 'reuse of aggregates' do
               let(:years) { TimeRangeArray.make(range_type, start, finish) }
 
-              context 'and some aggregates were created previously' do
-                before do
-                  Aggregate.formatted_amount(function, account, transfer_code, years[0])
-                  Aggregate.formatted_amount(function, account, transfer_code, years[1])
-                  allow(Aggregate).to receive(:formatted_amount)
+              before do
+                Aggregate.formatted_amount(function, account, transfer_code, years[0])
+                Aggregate.formatted_amount(function, account, transfer_code, years[1])
+                allow(Aggregate).to receive(:formatted_amount)
+              end
+
+              context 'and the transfer code is not provided' do
+                let(:transfer_code) { nil }
+
+                it 'only asks Aggregate for the non-existent ones' do
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], filter: nil, partner_account: nil)
+                  expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[1], filter: nil, partner_account: nil)
+
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[2], filter: nil, partner_account: nil)
+                  expect(Aggregate).to receive(:formatted_amount).with(function, account, transfer_code, years[3], filter: nil, partner_account: nil)
+                  aggregate_array
                 end
+              end
+
+              context 'and the transfer code is provided' do
+                let(:transfer_code) { :bonus }
 
                 it 'only asks Aggregate for the non-existent ones' do
                   expect(Aggregate).not_to receive(:formatted_amount).with(function, account, transfer_code, years[0], filter: nil, partner_account: nil)

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -33,43 +33,45 @@ module DoubleEntry
             describe 'reuse of aggregates' do
               let(:years) { TimeRangeArray.make(range_type, start, finish) }
 
-              before do
-                Aggregate.formatted_amount(function, account, transfer_code, years[0])
-                Aggregate.formatted_amount(function, account, transfer_code, years[1])
-                allow(Aggregate).to receive(:formatted_amount)
-              end
-
-              context 'and the transfer code is not provided' do
-                let(:transfer_code) { nil }
-
-                it 'only asks Aggregate for the non-existent ones' do
-                  expect(Aggregate).not_to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
-                  expect(Aggregate).not_to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
-
-                  expect(Aggregate).to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
-                  expect(Aggregate).to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
-                  aggregate_array
+              context 'and some aggregates were created previously' do
+                before do
+                  Aggregate.formatted_amount(function, account, transfer_code, years[0])
+                  Aggregate.formatted_amount(function, account, transfer_code, years[1])
+                  allow(Aggregate).to receive(:formatted_amount)
                 end
-              end
 
-              context 'and the transfer code is provided' do
-                let(:transfer_code) { :bonus }
+                context 'and the transfer code is not provided' do
+                  let(:transfer_code) { nil }
 
-                it 'only asks Aggregate for the non-existent ones' do
-                  expect(Aggregate).not_to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
-                  expect(Aggregate).not_to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
+                  it 'only asks Aggregate for the non-existent ones' do
+                    expect(Aggregate).not_to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
+                    expect(Aggregate).not_to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
 
-                  expect(Aggregate).to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
-                  expect(Aggregate).to receive(:formatted_amount).
-                    with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
-                  aggregate_array
+                    expect(Aggregate).to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
+                    expect(Aggregate).to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
+                    aggregate_array
+                  end
+                end
+
+                context 'and the transfer code is provided' do
+                  let(:transfer_code) { :bonus }
+
+                  it 'only asks Aggregate for the non-existent ones' do
+                    expect(Aggregate).not_to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
+                    expect(Aggregate).not_to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
+
+                    expect(Aggregate).to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
+                    expect(Aggregate).to receive(:formatted_amount).
+                      with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
+                    aggregate_array
+                  end
                 end
               end
             end

--- a/spec/double_entry/reporting/aggregate_array_spec.rb
+++ b/spec/double_entry/reporting/aggregate_array_spec.rb
@@ -9,7 +9,14 @@ module DoubleEntry
       let(:account) { :savings }
       let(:transfer_code) { :bonus }
       subject(:aggregate_array) do
-        AggregateArray.new(function, account, transfer_code, range_type: range_type, start: start, finish: finish)
+        AggregateArray.new(
+          function: function,
+          account: account,
+          code: transfer_code,
+          range_type: range_type,
+          start: start,
+          finish: finish,
+        )
       end
 
       context 'given a deposit was made in 2007 and 2008' do
@@ -35,8 +42,8 @@ module DoubleEntry
 
               context 'and some aggregates were created previously' do
                 before do
-                  Aggregate.formatted_amount(function, account, transfer_code, years[0])
-                  Aggregate.formatted_amount(function, account, transfer_code, years[1])
+                  Aggregate.formatted_amount(function: function, account: account, code: transfer_code, range: years[0])
+                  Aggregate.formatted_amount(function: function, account: account, code: transfer_code, range: years[1])
                   allow(Aggregate).to receive(:formatted_amount)
                 end
 
@@ -45,32 +52,40 @@ module DoubleEntry
 
                   it 'only asks Aggregate for the non-existent ones' do
                     expect(Aggregate).not_to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
+                      with(function: function, account: account, code: transfer_code,
+                           range: years[0], partner_account: nil, filter: nil)
                     expect(Aggregate).not_to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
+                      with(function: function, account: account, code: transfer_code,
+                           range: years[1], partner_account: nil, filter: nil)
 
                     expect(Aggregate).to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
+                      with(function: function, account: account, code: transfer_code,
+                           range: years[2], partner_account: nil, filter: nil)
                     expect(Aggregate).to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
+                      with(function: function, account: account, code: transfer_code,
+                           range: years[3], partner_account: nil, filter: nil)
                     aggregate_array
                   end
-                end
 
-                context 'and the transfer code is provided' do
-                  let(:transfer_code) { :bonus }
+                  context 'and the transfer code is provided' do
+                    let(:transfer_code) { :bonus }
 
-                  it 'only asks Aggregate for the non-existent ones' do
-                    expect(Aggregate).not_to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[0], partner_account: nil, filter: nil)
-                    expect(Aggregate).not_to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[1], partner_account: nil, filter: nil)
+                    it 'only asks Aggregate for the non-existent ones' do
+                      expect(Aggregate).not_to receive(:formatted_amount).
+                        with(function: function, account: account, code: transfer_code,
+                             range: years[0], partner_account: nil, filter: nil)
+                      expect(Aggregate).not_to receive(:formatted_amount).
+                        with(function: function, account: account, code: transfer_code,
+                             range: years[1], partner_account: nil, filter: nil)
 
-                    expect(Aggregate).to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[2], partner_account: nil, filter: nil)
-                    expect(Aggregate).to receive(:formatted_amount).
-                      with(function, account, transfer_code, years[3], partner_account: nil, filter: nil)
-                    aggregate_array
+                      expect(Aggregate).to receive(:formatted_amount).
+                        with(function: function, account: account, code: transfer_code,
+                             range: years[2], partner_account: nil, filter: nil)
+                      expect(Aggregate).to receive(:formatted_amount).
+                        with(function: function, account: account, code: transfer_code,
+                             range: years[3], partner_account: nil, filter: nil)
+                      aggregate_array
+                    end
                   end
                 end
               end

--- a/spec/double_entry/reporting/aggregate_spec.rb
+++ b/spec/double_entry/reporting/aggregate_spec.rb
@@ -100,12 +100,6 @@ module DoubleEntry
         Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
         Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
         Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
-      end
-
-      it 'should only store the aggregate once if it is requested more than once' do
-        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
         expect(LineAggregate.count).to eq 2
         expect(LineAggregate).to have_received(:aggregate).twice
       end

--- a/spec/double_entry/reporting/aggregate_spec.rb
+++ b/spec/double_entry/reporting/aggregate_spec.rb
@@ -37,7 +37,7 @@ module DoubleEntry
       end
 
       it 'should store the aggregate for quick retrieval' do
-        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
         expect(LineAggregate.count).to eq 1
       end
 
@@ -61,85 +61,91 @@ module DoubleEntry
 
           context 'when the partner_account is supplied' do
             it 'calculates the complete year correctly for deposit fees' do
-              amount = Aggregate.new(:sum, :savings, :fee, TimeRange.make(:year => 2009), partner_account: :deposit_fees).formatted_amount
+              amount = Aggregate.new(function: :sum, account: :savings, code: :fee, range: TimeRange.make(:year => 2009), partner_account: :deposit_fees).formatted_amount
               expect(amount).to eq (Money.new(-4_00))
             end
 
             it 'calculates the complete year correctly for account fees' do
-              amount = Aggregate.new(:sum, :savings, :fee, TimeRange.make(:year => 2009), partner_account: :account_fees).formatted_amount
+              amount = Aggregate.new(function: :sum, account: :savings, code: :fee, range: TimeRange.make(:year => 2009), partner_account: :account_fees).formatted_amount
               expect(amount).to eq (Money.new(-2_00))
             end
           end
 
           context 'when the partner_account is not supplied' do
             it 'calculates the complete year correctly for all fees' do
-              amount = Aggregate.new(:sum, :savings, :fee, TimeRange.make(:year => 2009)).formatted_amount
+              amount = Aggregate.new(function: :sum, account: :savings, code: :fee, range: TimeRange.make(:year => 2009)).formatted_amount
               expect(amount).to eq (Money.new(-6_00))
             end
           end
         end
 
         it 'calculates a new aggregate when partner_account is specified' do
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9)).amount
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
           expect(LineAggregate.count).to eq 3
           expect(LineAggregate).to have_received(:aggregate).exactly(3).times
         end
 
         it "only stores an aggregate including partner_account once if it's requested more than once" do
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
-          Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10), partner_account: :test).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9), partner_account: :test).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10), partner_account: :test).amount
           expect(LineAggregate.count).to eq 2
           expect(LineAggregate).to have_received(:aggregate).twice
         end
       end
 
       it 'only stores the aggregate once if it is requested more than once' do
-        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 9)).amount
-        Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
+      end
+
+      it 'should only store the aggregate once if it is requested more than once' do
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 9)).amount
+        Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).amount
         expect(LineAggregate.count).to eq 2
         expect(LineAggregate).to have_received(:aggregate).twice
       end
 
       it 'calculates the complete year correctly' do
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009)).formatted_amount
         expect(amount).to eq Money.new(200_00)
       end
 
-      it 'calculates separate months correctly' do
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 10)).formatted_amount
+      it 'calculates seperate months correctly' do
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 10)).formatted_amount
         expect(amount).to eq Money.new(110_00)
 
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 11)).formatted_amount
         expect(amount).to eq Money.new(90_00)
       end
 
       it 'calculates separate weeks correctly' do
         # Week 40 - Mon Sep 28, 2009 to Sun Oct 4 2009
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 40)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 40)).formatted_amount
         expect(amount).to eq Money.new(60_00)
       end
 
       it 'calculates separate days correctly' do
         # 1 Nov 2009
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 44, :day => 7)).formatted_amount
         expect(amount).to eq Money.new(90_00)
       end
 
       it 'calculates separate hours correctly' do
         # 1 Nov 2009
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 0)).formatted_amount
         expect(amount).to eq Money.new(40_00)
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 44, :day => 7, :hour => 1)).formatted_amount
         expect(amount).to eq Money.new(50_00)
       end
 
       it 'calculates, but not store aggregates when the time range is still current' do
         Timecop.freeze Time.local(2009, 11, 21) do
-          amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 11)).formatted_amount
+          amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 11)).formatted_amount
           expect(amount).to eq Money.new(90_00)
           expect(LineAggregate.count).to eq 0
         end
@@ -147,46 +153,46 @@ module DoubleEntry
 
       it 'calculates, but not store aggregates when the time range is in the future' do
         Timecop.freeze Time.local(2009, 11, 21) do
-          amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12)).formatted_amount
+          amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 12)).formatted_amount
           expect(amount).to eq Money.new(0)
           expect(LineAggregate.count).to eq 0
         end
       end
 
       it 'calculates monthly all_time ranges correctly' do
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
         expect(amount).to eq Money.new(200_00)
       end
 
       it 'calculates the average monthly all_time ranges correctly' do
-        amount = Aggregate.new(:average, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :average, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
         expect(amount).to eq expected_monthly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
-        amount = Aggregate.new(:count, :savings, :bonus, TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :count, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :month => 12, :range_type => :all_time)).formatted_amount
         expect(amount).to eq 5
       end
 
       it 'calculates weekly all_time ranges correctly' do
-        amount = Aggregate.new(:sum, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
         expect(amount).to eq Money.new(110_00)
       end
 
       it 'calculates the average weekly all_time ranges correctly' do
-        amount = Aggregate.new(:average, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :average, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
         expect(amount).to eq expected_weekly_average
       end
 
       it 'returns the correct count for weekly all_time ranges correctly' do
-        amount = Aggregate.new(:count, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
+        amount = Aggregate.new(function: :count, account: :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)).formatted_amount
         expect(amount).to eq 3
       end
 
       it 'raises an AggregateFunctionNotSupported exception' do
         expect do
-          Aggregate.new(
-            :not_supported_calculation, :savings, :bonus, TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
+          Aggregate.new(function:
+            :not_supported_calculation,account:  :savings, code: :bonus, range: TimeRange.make(:year => 2009, :week => 43, :range_type => :all_time)
           ).amount
         end.to raise_error(AggregateFunctionNotSupported)
       end
@@ -217,34 +223,34 @@ module DoubleEntry
 
         it 'saves filtered aggregations' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
+            Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).amount
           end.to change { LineAggregate.count }.by 1
         end
 
         it 'saves filtered aggregation only once for a range' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
-            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
+            Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).amount
+            Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).amount
           end.to change { LineAggregate.count }.by 1
         end
 
         it 'saves filtered aggregations and non filtered aggregations separately' do
           expect do
-            Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
-            Aggregate.new(:sum, :savings, :bonus, range).amount
+            Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).amount
+            Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range).amount
           end.to change { LineAggregate.count }.by 2
         end
 
         it 'loads the correct saved aggregation' do
           # cache the results for filtered and unfiltered aggregations
-          Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).amount
-          Aggregate.new(:sum, :savings, :bonus, range).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).amount
+          Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range).amount
 
           # ensure a second call loads the correct cached value
-          amount = Aggregate.new(:sum, :savings, :bonus, range, :filter => filter).formatted_amount
+          amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range, :filter => filter).formatted_amount
           expect(amount).to eq Money.new(10_00)
 
-          amount = Aggregate.new(:sum, :savings, :bonus, range).formatted_amount
+          amount = Aggregate.new(function: :sum, account: :savings, code: :bonus, range: range).formatted_amount
           expect(amount).to eq Money.new(19_00)
         end
       end
@@ -257,7 +263,7 @@ module DoubleEntry
       end
 
       it 'calculates the sum in the correct currency' do
-        amount = Aggregate.new(:sum, :btc_savings, :btc_test_transfer, TimeRange.make(:year => Time.now.year)).formatted_amount
+        amount = Aggregate.new(function: :sum, account: :btc_savings, code: :btc_test_transfer, range: TimeRange.make(:year => Time.now.year)).formatted_amount
         expect(amount).to eq(Money.new(300_000_000, :btc))
       end
     end

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -15,7 +15,13 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
     let(:lines_scope) { spy(DoubleEntry::Line) }
 
     subject(:filter) do
-      DoubleEntry::Reporting::LineAggregateFilter.new(account, partner_account, code, range, filter_criteria)
+      DoubleEntry::Reporting::LineAggregateFilter.new(
+        account: account,
+        partner_account: partner_account,
+        code: code,
+        range: range,
+        filter_criteria: filter_criteria
+      )
     end
 
     before do

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
     let(:account) { :account }
     let(:code) { :transfer_code }
     let(:filter_criteria) { nil }
+    let(:partner_account) { nil }
     let(:start) { Time.parse('2014-07-27 10:55:44 +1000') }
     let(:finish) { Time.parse('2015-07-27 10:55:44 +1000') }
     let(:range) do
@@ -14,7 +15,7 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
     let(:lines_scope) { spy(DoubleEntry::Line) }
 
     subject(:filter) do
-      DoubleEntry::Reporting::LineAggregateFilter.new(account, code, range, filter_criteria)
+      DoubleEntry::Reporting::LineAggregateFilter.new(account, code, range, filter_criteria, partner_account)
     end
 
     before do

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -75,8 +75,9 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
       end
     end
 
-    context 'with a code specified' do
+    context 'with a code specified and partner_account not specified' do
       let(:code) { :transfer_code }
+      let(:partner_account) { nil }
 
       it 'retrieves the appropriate lines for aggregation' do
         expect(DoubleEntry::Line).to have_received(:where).with(:account => account)
@@ -85,7 +86,8 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
       end
     end
 
-    context 'with a partner_account specified' do
+    context 'with a partner_account specified and code not specified' do
+      let(:code) { nil }
       let(:partner_account) { :partner_account }
 
       it 'retrieves the appropriate lines for aggregation' do

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -79,8 +79,31 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
       end
     end
 
-    context 'with no code specified' do
+    context 'with a partner_account specified' do
+      let(:partner_account) { :partner_account }
+
+      it 'retrieves the appropriate lines for aggregation' do
+        expect(DoubleEntry::Line).to have_received(:where).with(:account => account)
+        expect(DoubleEntry::Line).to have_received(:where).with(:created_at => start..finish)
+        expect(DoubleEntry::Line).to have_received(:where).with(:partner_account => partner_account)
+      end
+    end
+
+    context 'with code and partner_account specified' do
+      let(:code) { :transfer_code }
+      let(:partner_account) { :partner_account }
+
+      it 'retrieves the appropriate lines for aggregation' do
+        expect(DoubleEntry::Line).to have_received(:where).with(:account => account)
+        expect(DoubleEntry::Line).to have_received(:where).with(:created_at => start..finish)
+        expect(DoubleEntry::Line).to have_received(:where).with(:code => code)
+        expect(DoubleEntry::Line).to have_received(:where).with(:partner_account => partner_account)
+      end
+    end
+
+    context 'with no code or partner_account specified' do
       let(:code) { nil }
+      let(:partner_account) { nil }
 
       it 'retrieves the appropriate lines for aggregation' do
         expect(DoubleEntry::Line).to have_received(:where).with(:account => account)

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
     let(:lines_scope) { spy(DoubleEntry::Line) }
 
     subject(:filter) do
-      DoubleEntry::Reporting::LineAggregateFilter.new(account, code, range, filter_criteria, partner_account)
+      DoubleEntry::Reporting::LineAggregateFilter.new(account, partner_account, code, range, filter_criteria)
     end
 
     before do

--- a/spec/double_entry/reporting/line_aggregate_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe DoubleEntry::Reporting::LineAggregate do
     let(:function) { :sum }
     let(:account) { spy }
     let(:code) { spy }
+    let(:partner_account) { spy }
     let(:named_scopes) { spy }
     let(:range) { spy }
 
     subject(:aggregate) do
-      DoubleEntry::Reporting::LineAggregate.aggregate(function, account, code, range, named_scopes)
+      DoubleEntry::Reporting::LineAggregate.aggregate(function, account, code, range, named_scopes, partner_account)
     end
 
     before do
@@ -28,7 +29,7 @@ RSpec.describe DoubleEntry::Reporting::LineAggregate do
 
     it 'applies the specified filters' do
       expect(DoubleEntry::Reporting::LineAggregateFilter).to have_received(:new).
-        with(account, code, range, named_scopes)
+        with(account, code, range, named_scopes, partner_account)
       expect(filter).to have_received(:filter)
     end
 

--- a/spec/double_entry/reporting/line_aggregate_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_spec.rb
@@ -6,30 +6,31 @@ RSpec.describe DoubleEntry::Reporting::LineAggregate do
   end
 
   describe '#aggregate' do
-    let(:line_relation) { spy }
+    let(:line_relation) { double }
     let(:filter) do
       instance_double(DoubleEntry::Reporting::LineAggregateFilter, :filter => line_relation)
     end
 
     let(:function) { :sum }
-    let(:account) { spy }
-    let(:code) { spy }
-    let(:partner_account) { spy }
-    let(:named_scopes) { spy }
-    let(:range) { spy }
+    let(:account) { double }
+    let(:code) { double }
+    let(:partner_account) { double }
+    let(:named_scopes) { double }
+    let(:range) { double }
 
     subject(:aggregate) do
-      DoubleEntry::Reporting::LineAggregate.aggregate(function, account, code, range, named_scopes, partner_account)
+      DoubleEntry::Reporting::LineAggregate.aggregate(function, account, partner_account, code, range, named_scopes)
     end
 
     before do
       allow(DoubleEntry::Reporting::LineAggregateFilter).to receive(:new).and_return(filter)
+      allow(line_relation).to receive(:sum).with(:amount)
       aggregate
     end
 
     it 'applies the specified filters' do
       expect(DoubleEntry::Reporting::LineAggregateFilter).to have_received(:new).
-        with(account, code, range, named_scopes, partner_account)
+        with(account, partner_account, code, range, named_scopes)
       expect(filter).to have_received(:filter)
     end
 

--- a/spec/double_entry/reporting/line_aggregate_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_spec.rb
@@ -19,7 +19,14 @@ RSpec.describe DoubleEntry::Reporting::LineAggregate do
     let(:range) { double }
 
     subject(:aggregate) do
-      DoubleEntry::Reporting::LineAggregate.aggregate(function, account, partner_account, code, range, named_scopes)
+      DoubleEntry::Reporting::LineAggregate.aggregate(
+        function: function,
+        account: account,
+        partner_account: partner_account,
+        code: code,
+        range: range,
+        named_scopes: named_scopes
+      )
     end
 
     before do
@@ -30,7 +37,8 @@ RSpec.describe DoubleEntry::Reporting::LineAggregate do
 
     it 'applies the specified filters' do
       expect(DoubleEntry::Reporting::LineAggregateFilter).to have_received(:new).
-        with(account, partner_account, code, range, named_scopes)
+        with(account: account, partner_account: partner_account, code: code,
+             range: range, filter_criteria: named_scopes)
       expect(filter).to have_received(:filter)
     end
 

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -114,8 +114,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(
-          function, account, code, range,
+        DoubleEntry::Reporting.aggregate(function, account, code, range,
           filter: [
             :scope => {
               :name => :ten_dollar_transfers,
@@ -142,8 +141,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(
-          function, account, code, range,
+        DoubleEntry::Reporting.aggregate(function, account, code, range,
           filter: [
             :scope => {
               :name      => :specific_transfer_amount,
@@ -171,8 +169,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(
-          function, account, code, range,
+        DoubleEntry::Reporting.aggregate(function, account, code, range,
           filter: [
             :metadata => {
               :reason => 'payday',
@@ -193,7 +190,9 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
       let(:partner_account) { :service_fees }
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range, partner_account: partner_account)
+        DoubleEntry::Reporting.aggregate(function, account, code, range,
+          partner_account: partner_account,
+        )
       end
 
       specify 'Total amount of service fees paid' do

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 RSpec.describe DoubleEntry::Reporting do
-  describe '::configure' do
+  describe 'configuration' do
     describe 'start_of_business' do
       subject(:start_of_business) { DoubleEntry::Reporting.configuration.start_of_business }
 
@@ -20,7 +20,7 @@ RSpec.describe DoubleEntry::Reporting do
     end
   end
 
-  describe '::scopes_with_minimum_balance_for_account' do
+  describe '.scopes_with_minimum_balance_for_account' do
     subject(:scopes) { DoubleEntry::Reporting.scopes_with_minimum_balance_for_account(minimum_balance, :checking) }
 
     context "a 'checking' account with balance $100" do
@@ -43,7 +43,7 @@ RSpec.describe DoubleEntry::Reporting do
     end
   end
 
-  describe '::aggregate' do
+  describe '.aggregate' do
     before do
       # get rid of "helpful" predefined config
       @config_accounts  = DoubleEntry.configuration.accounts
@@ -189,11 +189,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:code) { :fees }
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
       let(:partner_account) { :service_fees }
-      subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range,
-          partner_account: partner_account,
-        )
-      end
+      subject(:aggregate) { DoubleEntry::Reporting.aggregate(function, account, code, range, partner_account: partner_account) }
 
       specify 'Total amount of service fees paid' do
         expect(aggregate).to eq(Money.new(-70_00))

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range)
+        DoubleEntry::Reporting.aggregate(function: function, account: account, code: code, range: range)
       end
 
       specify 'Total attempted to save' do
@@ -114,7 +114,11 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range,
+        DoubleEntry::Reporting.aggregate(
+          function: function,
+          account: account,
+          code: code,
+          range: range,
           filter: [
             :scope => {
               :name => :ten_dollar_transfers,
@@ -141,7 +145,11 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range,
+        DoubleEntry::Reporting.aggregate(
+          function: function,
+          account: account,
+          code: code,
+          range: range,
           filter: [
             :scope => {
               :name      => :specific_transfer_amount,
@@ -169,7 +177,11 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
 
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate(function, account, code, range,
+        DoubleEntry::Reporting.aggregate(
+          function: function,
+          account: account,
+          code: code,
+          range: range,
           filter: [
             :metadata => {
               :reason => 'payday',
@@ -189,7 +201,15 @@ RSpec.describe DoubleEntry::Reporting do
       let(:code) { :fees }
       let(:range) { DoubleEntry::Reporting::MonthRange.current }
       let(:partner_account) { :service_fees }
-      subject(:aggregate) { DoubleEntry::Reporting.aggregate(function, account, code, range, partner_account: partner_account) }
+      subject(:aggregate) do
+        DoubleEntry::Reporting.aggregate(
+          function: function,
+          account: account,
+          code: code,
+          range: range,
+          partner_account: partner_account
+        )
+      end
 
       specify 'Total amount of service fees paid' do
         expect(aggregate).to eq(Money.new(-70_00))
@@ -244,7 +264,13 @@ RSpec.describe DoubleEntry::Reporting do
       let(:account) { :savings }
       let(:code) { :fees }
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate_array(function, account, code, range_type: 'year', start: '2015-01-01')
+        DoubleEntry::Reporting.aggregate_array(
+          function: function,
+          account: account,
+          code: code,
+          range_type: 'year',
+          start: '2015-01-01'
+        )
       end
 
       before do
@@ -262,7 +288,10 @@ RSpec.describe DoubleEntry::Reporting do
       let(:range_type) { 'year' }
       let(:partner_account) { :service_fees }
       subject(:aggregate) do
-        DoubleEntry::Reporting.aggregate_array(function, account, code,
+        DoubleEntry::Reporting.aggregate_array(
+          function: function,
+          account: account,
+          code: code,
           partner_account: partner_account,
           range_type: range_type,
           start: start,

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -4,18 +4,22 @@ DoubleEntry.configure do |config|
   # A set of accounts to test with
   config.define_accounts do |accounts|
     user_scope = accounts.active_record_scope_identifier(User)
-    accounts.define(:identifier => :savings,     :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :checking,    :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :test,        :scope_identifier => user_scope)
-    accounts.define(:identifier => :btc_test,    :scope_identifier => user_scope, :currency => 'BTC')
-    accounts.define(:identifier => :btc_savings, :scope_identifier => user_scope, :currency => 'BTC')
+    accounts.define(:identifier => :savings,      :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :checking,     :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :test,         :scope_identifier => user_scope)
+    accounts.define(:identifier => :btc_test,     :scope_identifier => user_scope, :currency => 'BTC')
+    accounts.define(:identifier => :btc_savings,  :scope_identifier => user_scope, :currency => 'BTC')
+    accounts.define(:identifier => :deposit_fees, :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(:identifier => :account_fees, :scope_identifier => user_scope, :positive_only => true)
   end
 
   # A set of allowed transfers between accounts
   config.define_transfers do |transfers|
-    transfers.define(:from => :test,     :to => :savings,     :code => :bonus)
-    transfers.define(:from => :test,     :to => :checking,    :code => :pay)
-    transfers.define(:from => :savings,  :to => :test,        :code => :test_withdrawal)
-    transfers.define(:from => :btc_test, :to => :btc_savings, :code => :btc_test_transfer)
+    transfers.define(:from => :test,     :to => :savings,      :code => :bonus)
+    transfers.define(:from => :test,     :to => :checking,     :code => :pay)
+    transfers.define(:from => :savings,  :to => :test,         :code => :test_withdrawal)
+    transfers.define(:from => :btc_test, :to => :btc_savings,  :code => :btc_test_transfer)
+    transfers.define(:from => :savings,  :to => :deposit_fees, :code => :fee)
+    transfers.define(:from => :savings,  :to => :account_fees, :code => :fee)
   end
 end

--- a/spec/support/double_entry_spec_helper.rb
+++ b/spec/support/double_entry_spec_helper.rb
@@ -16,6 +16,24 @@ module DoubleEntrySpecHelper
     )
   end
 
+  def transfer_deposit_fee(user, amount)
+    DoubleEntry.transfer(
+      Money.new(amount),
+      :from => DoubleEntry.account(:savings, :scope => user),
+      :to   => DoubleEntry.account(:deposit_fees, :scope => user),
+      :code => :fee,
+    )
+  end
+
+  def transfer_account_fee(user, amount)
+    DoubleEntry.transfer(
+      Money.new(amount),
+      :from => DoubleEntry.account(:savings, :scope => user),
+      :to   => DoubleEntry.account(:account_fees, :scope => user),
+      :code => :fee,
+    )
+  end
+
   def perform_btc_deposit(user, amount)
     DoubleEntry.transfer(
       Money.new(amount, :btc),

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -31,19 +31,20 @@ ActiveRecord::Schema.define do
   add_index "double_entry_lines", ["scope", "account", "id"],         :name => "lines_scope_account_id_idx"
 
   create_table "double_entry_line_aggregates", :force => true do |t|
-    t.string     "function",   :limit => 15, :null => false
-    t.string     "account",    :limit => 31, :null => false
-    t.string     "code",       :limit => 47
-    t.string     "scope",      :limit => 23
+    t.string     "function",        :limit => 15, :null => false
+    t.string     "account",         :limit => 31, :null => false
+    t.string     "code",            :limit => 47
+    t.string     "partner_account", :limit => 31
+    t.string     "scope",           :limit => 23
     t.integer    "year"
     t.integer    "month"
     t.integer    "week"
     t.integer    "day"
     t.integer    "hour"
-    t.integer    "amount",                   :null => false
+    t.integer    "amount",                        :null => false
     t.string     "filter"
-    t.string     "range_type", :limit => 15, :null => false
-    t.timestamps                             :null => false
+    t.string     "range_type",      :limit => 15, :null => false
+    t.timestamps                                  :null => false
   end
 
   add_index "double_entry_line_aggregates", ["function", "account", "code", "year", "month", "week", "day"], :name => "line_aggregate_idx"

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -25,10 +25,10 @@ ActiveRecord::Schema.define do
     t.timestamps                                  :null => false
   end
 
-  add_index "double_entry_lines", ["account", "code", "created_at"],  :name => "lines_account_code_created_at_idx"
-  add_index "double_entry_lines", ["account", "created_at"],          :name => "lines_account_created_at_idx"
-  add_index "double_entry_lines", ["scope", "account", "created_at"], :name => "lines_scope_account_created_at_idx"
-  add_index "double_entry_lines", ["scope", "account", "id"],         :name => "lines_scope_account_id_idx"
+  add_index "double_entry_lines", ["account", "code", "created_at", "partner_account"],  :name => "lines_account_code_created_at_partner_account_idx"
+  add_index "double_entry_lines", ["account", "created_at"],                             :name => "lines_account_created_at_idx"
+  add_index "double_entry_lines", ["scope", "account", "created_at"],                    :name => "lines_scope_account_created_at_idx"
+  add_index "double_entry_lines", ["scope", "account", "id"],                            :name => "lines_scope_account_id_idx"
 
   create_table "double_entry_line_aggregates", :force => true do |t|
     t.string     "function",        :limit => 15, :null => false
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define do
     t.timestamps                                  :null => false
   end
 
-  add_index "double_entry_line_aggregates", ["function", "account", "code", "year", "month", "week", "day"], :name => "line_aggregate_idx"
+  add_index "double_entry_line_aggregates", ["function", "account", "code", "partner_account", "year", "month", "week", "day"], :name => "line_aggregate_idx"
 
   create_table "double_entry_line_checks", :force => true do |t|
     t.integer    "last_line_id", :null => false


### PR DESCRIPTION
Allow aggregations by partner_account to support reporting on the receiving account of transfers

For cases where you transfer from the same account using the same transfer code into different partner accounts, but want to report on the specific account/partner_account transfers.

Also introduced some keyword arguments to the aggregate API - these shouldn't affect existing calls as they just replace the options hash but do prevent the use of the double_entry gem with ruby < 2.0 (see https://github.com/envato/double_entry/pull/107 for removing ruby 1.9.3 support).  Note the build should go green once we've merged in #107, as the only tests failing are in the ruby 1.9.3 run.

Paired with @salamagd 