### PR TITLE
Allow filtering by multiple metadata key/value pairs

### DIFF
--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -9,6 +9,7 @@ require 'double_entry/reporting/month_range'
 require 'double_entry/reporting/year_range'
 require 'double_entry/reporting/line_aggregate'
 require 'double_entry/reporting/line_aggregate_filter'
+require 'double_entry/reporting/line_metadata_filter'
 require 'double_entry/reporting/time_range_array'
 
 module DoubleEntry

--- a/lib/double_entry/reporting/line_aggregate_filter.rb
+++ b/lib/double_entry/reporting/line_aggregate_filter.rb
@@ -2,6 +2,7 @@
 module DoubleEntry
   module Reporting
     class LineAggregateFilter
+
       def initialize(account:, partner_account:, code:, range:, filter_criteria:)
         @account         = account
         @partner_account = partner_account
@@ -44,10 +45,11 @@ module DoubleEntry
       #         :name => :ten_dollar_purchases
       #       }
       #     },
-      #     # an example of providing a single metadatum criteria to filter on
+      #     # an example of providing multiple metadatum criteria to filter on
       #     {
       #       :metadata => {
-      #         :meme => :business_cat
+      #         :meme => :business_cat,
+      #         :category => :fun_times,
       #       }
       #     }
       #   ]
@@ -68,13 +70,7 @@ module DoubleEntry
       end
 
       def filter_by_metadata(collection, metadata)
-        metadata.reduce(collection.joins(:metadata)) do |filtered_collection, (key, value)|
-          filtered_collection.where(metadata_table => { :key => key, :value => value })
-        end
-      end
-
-      def metadata_table
-        DoubleEntry::LineMetadata.table_name.to_sym
+        DoubleEntry::Reporting::LineMetadataFilter.filter(collection: collection, metadata: metadata)
       end
     end
   end

--- a/lib/double_entry/reporting/line_metadata_filter.rb
+++ b/lib/double_entry/reporting/line_metadata_filter.rb
@@ -1,0 +1,33 @@
+# encoding: utf-8
+module DoubleEntry
+  module Reporting
+    class LineMetadataFilter
+
+      def self.filter(collection:, metadata:)
+        table_alias_index = 0
+
+        metadata.reduce(collection) do |filtered_collection, (key, value)|
+          table_alias = "m#{table_alias_index}"
+          table_alias_index += 1
+
+          filtered_collection.
+            joins("INNER JOIN #{line_metadata_table} as #{table_alias} ON #{table_alias}.line_id = #{lines_table}.id").
+            where("#{table_alias}.key = ? AND #{table_alias}.value = ?", key, value)
+        end
+      end
+
+    private
+
+      def self.line_metadata_table
+        DoubleEntry::LineMetadata.table_name
+      end
+      private_class_method :line_metadata_table
+
+      def self.lines_table
+        DoubleEntry::Line.table_name
+      end
+      private_class_method :lines_table
+
+    end
+  end
+end

--- a/spec/double_entry/reporting/line_aggregate_filter_spec.rb
+++ b/spec/double_entry/reporting/line_aggregate_filter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
     before do
       stub_const('DoubleEntry::Line', lines_scope)
 
-      allow(DoubleEntry::LineMetadata).to receive(:table_name).and_return('double_entry_line_metadata')
+      allow(DoubleEntry::Reporting::LineMetadataFilter).to receive(:filter).and_call_original
 
       allow(lines_scope).to receive(:where).and_return(lines_scope)
       allow(lines_scope).to receive(:joins).and_return(lines_scope)
@@ -69,9 +69,8 @@ RSpec.describe DoubleEntry::Reporting::LineAggregateFilter do
       end
 
       it 'filters by all the metadata provided' do
-        expect(DoubleEntry::Line).to have_received(:joins).with(:metadata)
-        expect(DoubleEntry::Line).to have_received(:where).
-          with(:double_entry_line_metadata => { :key => :meme, :value => 'business_cat' })
+        expect(DoubleEntry::Reporting::LineMetadataFilter).to have_received(:filter).
+          with(collection: anything, metadata: { :meme => 'business_cat'})
       end
     end
 

--- a/spec/double_entry/reporting/line_metadata_filter_spec.rb
+++ b/spec/double_entry/reporting/line_metadata_filter_spec.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+RSpec.describe DoubleEntry::Reporting::LineMetadataFilter do
+  describe '.filter' do
+    let(:collection) { DoubleEntry::Line }
+    let(:metadata) {
+      {
+        :meme  => 'business_cat',
+        :genre => 'comedy',
+      }
+    }
+
+    subject(:filter) { DoubleEntry::Reporting::LineMetadataFilter.filter(collection: collection, metadata: metadata) }
+
+    before do
+      allow(collection).to receive(:joins).and_return(collection)
+      allow(collection).to receive(:where).and_return(collection)
+      allow(DoubleEntry::LineMetadata).to receive(:table_name).and_return('double_entry_line_metadata')
+      allow(DoubleEntry::Line).to receive(:table_name).and_return('double_entry_lines')
+      filter
+    end
+
+    it 'queries for matches to the first key value pair' do
+      expect(collection).to have_received(:joins).
+        with('INNER JOIN double_entry_line_metadata as m0 ON m0.line_id = double_entry_lines.id')
+      expect(collection).to have_received(:where).
+        with('m0.key = ? AND m0.value = ?', :meme, 'business_cat')
+    end
+
+    it 'queries for matches to the second key value pair' do
+      expect(collection).to have_received(:joins).
+       with('INNER JOIN double_entry_line_metadata as m1 ON m1.line_id = double_entry_lines.id')
+      expect(collection).to have_received(:where).
+        with('m1.key = ? AND m1.value = ?', :genre, 'comedy')
+    end
+  end
+end

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe DoubleEntry::Reporting do
       credit       = DoubleEntry.account(:credit)
       service_fees = DoubleEntry.account(:service_fees)
       account_fees = DoubleEntry.account(:account_fees)
+      DoubleEntry.transfer(Money.new(10_00), :from => cash,    :to => savings,      :code => :save, :metadata => { :reason => 'payday', :save_for => 'cats' })
       DoubleEntry.transfer(Money.new(10_00), :from => cash,    :to => savings,      :code => :save, :metadata => { :reason => 'payday' })
-      DoubleEntry.transfer(Money.new(10_00), :from => cash,    :to => savings,      :code => :save, :metadata => { :reason => 'payday' })
+      DoubleEntry.transfer(Money.new(11_00), :from => cash,    :to => savings,      :code => :save, :metadata => { :reason => 'payday', :save_for => 'dogs' })
       DoubleEntry.transfer(Money.new(20_00), :from => cash,    :to => savings,      :code => :save)
       DoubleEntry.transfer(Money.new(20_00), :from => cash,    :to => savings,      :code => :save)
       DoubleEntry.transfer(Money.new(30_00), :from => cash,    :to => credit,       :code => :bill)
@@ -103,7 +104,7 @@ RSpec.describe DoubleEntry::Reporting do
       end
 
       specify 'Total attempted to save' do
-        expect(aggregate).to eq(Money.new(60_00))
+        expect(aggregate).to eq(Money.new(71_00))
       end
     end
 
@@ -182,16 +183,37 @@ RSpec.describe DoubleEntry::Reporting do
           account: account,
           code: code,
           range: range,
-          filter: [
+          filter: filter,
+        )
+      end
+
+      context 'filtering by a single metadata key/value pair' do
+        let(:filter) do
+          [
             :metadata => {
               :reason => 'payday',
             },
           ]
-        )
+        end
+
+        specify 'Total amount of transfers saved because payday' do
+          expect(aggregate).to eq(Money.new(31_00))
+        end
       end
 
-      specify 'Total amount of transfers saved because payday' do
-        expect(aggregate).to eq(Money.new(20_00))
+      context 'filtering by multiple metadata key/value pairs' do
+        let(:filter) do
+          [
+            :metadata => {
+              :reason => 'payday',
+              :save_for => 'dogs',
+            },
+          ]
+        end
+
+        specify 'Total amount of transfers saved for dogs because payday' do
+          expect(aggregate).to eq(Money.new(11_00))
+        end
       end
     end
 


### PR DESCRIPTION
We would like to be able to aggregate lines data by filtering for multiple pairs of metadata key/values.  

This is assumed to be an **AND** operation for now.  Specifying multiple key/value pairs for metadata filtering means that the line must have all of the metadata provided to be included in the aggregation.

