### PR TITLE
Support passing array of metadata value

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ DoubleEntry.transfer(
   :from => one_account,
   :to   => another_account,
   :code => :a_business_code_for_this_type_of_transfer,
-  :metadata => {:key1 => 'value 1', :key2 => 'value 2'},
+  :metadata => {:key1 => ['value 1', 'value 2'], :key2 => 'value 3'},
 )
 ```
 

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -115,14 +115,9 @@ module DoubleEntry
 
     def create_line_metadata(credit, debit, metadata)
       metadata.each_pair do |key, value|
-        if value.is_a?(Array)
-          value.each do |each_value|
-            LineMetadata.create!(:line => credit, :key => key, :value => each_value)
-            LineMetadata.create!(:line => debit, :key => key, :value => each_value)
-          end
-        else
-          LineMetadata.create!(:line => credit, :key => key, :value => value)
-          LineMetadata.create!(:line => debit, :key => key, :value => value)
+        Array(value).each do |each_value|
+          LineMetadata.create!(:line => credit, :key => key, :value => each_value)
+          LineMetadata.create!(:line => debit, :key => key, :value => each_value)
         end
       end
     end

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -115,8 +115,15 @@ module DoubleEntry
 
     def create_line_metadata(credit, debit, metadata)
       metadata.each_pair do |key, value|
-        LineMetadata.create!(:line => credit, :key => key, :value => value)
-        LineMetadata.create!(:line => debit, :key => key, :value => value)
+        if value.is_a?(Array)
+          value.each do |each_value|
+            LineMetadata.create!(:line => credit, :key => key, :value => each_value)
+            LineMetadata.create!(:line => debit, :key => key, :value => each_value)
+          end
+        else
+          LineMetadata.create!(:line => credit, :key => key, :value => value)
+          LineMetadata.create!(:line => debit, :key => key, :value => value)
+        end
       end
     end
   end

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DoubleEntry::Reporting do
       DoubleEntry.transfer(Money.new(30_00), :from => cash,    :to => credit,       :code => :bill)
       DoubleEntry.transfer(Money.new(40_00), :from => cash,    :to => credit,       :code => :bill)
       DoubleEntry.transfer(Money.new(50_00), :from => savings, :to => cash,         :code => :spend)
-      DoubleEntry.transfer(Money.new(60_00), :from => savings, :to => cash,         :code => :spend, :metadata => { :category => 'entertainment' })
+      DoubleEntry.transfer(Money.new(60_00), :from => savings, :to => cash,         :code => :spend, :metadata => { :category => ['entertainment', 'training'] })
       DoubleEntry.transfer(Money.new(70_00), :from => savings, :to => service_fees, :code => :fees)
       DoubleEntry.transfer(Money.new(80_00), :from => savings, :to => account_fees, :code => :fees)
     end
@@ -199,6 +199,34 @@ RSpec.describe DoubleEntry::Reporting do
         specify 'Total amount of transfers saved because payday' do
           expect(aggregate).to eq(Money.new(31_00))
         end
+      end
+
+      context 'filtering by key with multiple values' do
+        let(:code) { :spend }
+        let(:filter) do
+          [
+            :metadata => {
+              :category => category,
+            },
+          ]
+        end
+
+        context 'filter by category entertainment' do
+          let(:category) { 'entertainment' }
+
+          specify 'Total amount of transfers spent because entertainment' do
+            expect(aggregate).to eq(-Money.new(60_00))
+          end
+        end
+
+        context 'filter by category training' do
+          let(:category) { 'training' }
+
+          specify 'Total amount of transfers spent because training' do
+            expect(aggregate).to eq(-Money.new(60_00))
+          end
+        end
+
       end
 
       context 'filtering by multiple metadata key/value pairs' do

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -72,6 +72,29 @@ module DoubleEntry
           expect(taxes.count { |meta| meta.value == 'GST' }).to be 2
         end
       end
+
+      context 'metadata with multiple values in array for one key' do
+        let(:options) { { :from => test, :to => savings, :code => :bonus, :metadata => { :tax => ['GST', 'VAT'] } } }
+        let(:new_metadata) { LineMetadata.all[-4..-1] }
+
+        it 'creates metadata lines' do
+          expect { transfer }.to change { LineMetadata.count }.by 4
+        end
+
+        it 'associates the metadata lines with the transfer lines' do
+          transfer
+          expect(new_metadata.count { |meta| meta.line == new_lines.first }).to be 2
+          expect(new_metadata.count { |meta| meta.line == new_lines.last }).to be 2
+        end
+
+        it 'stores both values to the same key' do
+          transfer
+          taxes = new_metadata.select { |meta| meta.key == :tax }
+          expect(taxes.size).to be 4
+          expect(taxes.count { |meta| meta.value == 'GST' }).to be 2
+          expect(taxes.map(&:line).uniq.size).to be 2
+        end
+      end
     end
 
     describe Transfer::Set do


### PR DESCRIPTION
It is quite common that we want to record multiple values for a metadata key when a money transfer is performed. For example: a money transfer can have multiple tags, categories, applied taxes.

This change will allow DoubleEntry gem users to do this:
```
DoubleEntry.transfer(
  amount,
  :from  => one_account,
  :to      => another_account,
  :code => :some_money_movement,
  :metadata => {:key1 => ['value 1', 'value 2'] }
```

Also added some test to ensure reporting still works correctly for money transfers like this.