### PR TITLE
Get off `active_record` notification namespace

### DIFF
--- a/lib/active_record/locking_extensions.rb
+++ b/lib/active_record/locking_extensions.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       yield
     rescue ActiveRecord::StatementInvalid => exception
       if exception.message =~ /deadlock/i || exception.message =~ /database is locked/i
-        ActiveSupport::Notifications.publish('deadlock_restart.active_record', :exception => exception)
+        ActiveSupport::Notifications.publish('deadlock_restart.double_entry', :exception => exception)
 
         raise ActiveRecord::RestartTransaction
       else
@@ -46,7 +46,7 @@ module ActiveRecord
       yield
     rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordNotUnique => exception
       if  exception.message =~ /duplicate/i || exception.message =~ /ConstraintException/
-        ActiveSupport::Notifications.publish('duplicate_ignore.active_record', :exception => exception)
+        ActiveSupport::Notifications.publish('duplicate_ignore.double_entry', :exception => exception)
 
         # Just ignore it...someone else has already created the record.
       else
@@ -63,7 +63,7 @@ module ActiveRecord
       if exception.message =~ /deadlock/i || exception.message =~ /database is locked/i
         # Somebody else is in the midst of creating the record. We'd better
         # retry, so we ensure they're done before we move on.
-        ActiveSupport::Notifications.publish('deadlock_retry.active_record', :exception => exception)
+        ActiveSupport::Notifications.publish('deadlock_retry.double_entry', :exception => exception)
 
         retry
       else

--- a/lib/active_record/locking_extensions/log_subscriber.rb
+++ b/lib/active_record/locking_extensions/log_subscriber.rb
@@ -26,4 +26,4 @@ module ActiveRecord
   end
 end
 
-ActiveRecord::LockingExtensions::LogSubscriber.attach_to :active_record
+ActiveRecord::LockingExtensions::LogSubscriber.attach_to :double_entry

--- a/spec/active_record/locking_extensions_spec.rb
+++ b/spec/active_record/locking_extensions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
       it 'publishes a notification' do
         expect(ActiveSupport::Notifications).
           to receive(:publish).
-          with('deadlock_restart.active_record', hash_including(:exception => exception))
+          with('deadlock_restart.double_entry', hash_including(:exception => exception))
         expect { User.with_restart_on_deadlock { fail exception } }.to raise_error
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
 
       expect(ActiveSupport::Notifications).
         to receive(:publish).
-        with('duplicate_ignore.active_record', hash_including(:exception => kind_of(ActiveRecord::RecordNotUnique)))
+        with('duplicate_ignore.double_entry', hash_including(:exception => kind_of(ActiveRecord::RecordNotUnique)))
 
       expect { User.create_ignoring_duplicates! :username => 'keith' }.to_not raise_error
     end
@@ -82,7 +82,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
 
         expect(ActiveSupport::Notifications).
           to receive(:publish).
-          with('deadlock_retry.active_record', hash_including(:exception => exception)).
+          with('deadlock_retry.double_entry', hash_including(:exception => exception)).
           twice
 
         expect { User.create_ignoring_duplicates! }.to_not raise_error


### PR DESCRIPTION
Double Entry does a great job of instrumenting various metrics by using
`ActiveSupport::Notifications` however it is currently using the
`active_record` namespace for it's events and it does not implement the
same number of arguments that the framework itself expects which causes
issues with third party gems expecting this.

To resolve this, I've updated the namespace used to instead be
`double_entry` which will allow the third party gems to differentiate
between this gem and the rails framework itself.