### PR TITLE
Cease support for Ruby 2.0.0

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables           = gem.files.grep(%r{bin/}).map { |f| File.basename(f) }
   gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths         = ['lib']
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.1.0'
 
   gem.post_install_message = <<-'POSTINSTALLMESSAGE'
 Please note the following changes in DoubleEntry:


### PR DESCRIPTION
Ruby 2.0.x has reached EOL. Time to retire the support.