### PR TITLE
Add test support for Ruby 2.4.1 and Rails 5.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,26 @@ matrix:
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql
     - rvm: 2.2.5
-      gemfile: spec/support/gemfiles/Gemfile.rails-5.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-5.1.x
       env: DB=mysql
     - rvm: 2.3.1
       gemfile: spec/support/gemfiles/Gemfile.rails-4.1.x
       env: DB=mysql
     - rvm: 2.3.1
+      gemfile: spec/support/gemfiles/Gemfile.rails-5.1.x
+      env: DB=mysql
+    - rvm: 2.4.1
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql
-    - rvm: 2.3.1
+    - rvm: 2.4.1
       gemfile: spec/support/gemfiles/Gemfile.rails-5.0.x
       env: DB=mysql
-    - rvm: 2.3.1
-      gemfile: spec/support/gemfiles/Gemfile.rails-5.0.x
+    - rvm: 2.4.1
+      gemfile: spec/support/gemfiles/Gemfile.rails-5.1.x
+      env: DB=mysql
+    - rvm: 2.4.1
+      gemfile: spec/support/gemfiles/Gemfile.rails-5.1.x
       env: DB=sqlite
-    - rvm: 2.3.1
-      gemfile: spec/support/gemfiles/Gemfile.rails-5.0.x
+    - rvm: 2.4.1
+      gemfile: spec/support/gemfiles/Gemfile.rails-5.1.x
       env: DB=postgres

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ Ruby
  * 2.1.x
  * 2.2.x
  * 2.3.x
+ * 2.4.x
 
 Rails
  * 3.2.x
  * 4.1.x
  * 4.2.x
  * 5.0.x
+ * 5.1.x
 
 Databases
  * MySQL

--- a/spec/support/gemfiles/Gemfile.rails-5.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.1.x
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../../../'
+
+gem 'rails', '~> 5.1.0'


### PR DESCRIPTION
Brings the "default" Ruby version in the majority of tests to 2.4.1, and tests against Rails 5.1 as well.