### PR TITLE
Back Transfer::Set and Account::Set with Hashes for performance benefits

### DIFF
--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -61,6 +61,16 @@ module DoubleEntry
         ActiveRecordScopeFactory.new(active_record_class).scope_identifier
       end
 
+      def each(&block)
+        backing_collection.values.each(&block)
+      end
+
+      def map(&block)
+        backing_collection.values.map do |account|
+          block.call(account)
+        end
+      end
+
       private
 
       def backing_collection

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'forwardable'
+
 module DoubleEntry
   class Account
     class << self
@@ -33,6 +35,10 @@ module DoubleEntry
 
     # @api private
     class Set
+      extend Forwardable
+
+      delegate [:each, :map] => :all
+
       def define(attributes)
         Account.new(attributes).tap do |account|
           if find_without_scope(account.identifier)
@@ -61,17 +67,11 @@ module DoubleEntry
         ActiveRecordScopeFactory.new(active_record_class).scope_identifier
       end
 
-      def each(&block)
-        backing_collection.values.each(&block)
+      def all
+        backing_collection.values
       end
 
-      def map(&block)
-        backing_collection.values.map do |account|
-          block.call(account)
-        end
-      end
-
-      private
+    private
 
       def backing_collection
         @backing_collection ||= Hash.new

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+require 'forwardable'
+
 module DoubleEntry
   class Transfer
     class << self
@@ -26,6 +28,9 @@ module DoubleEntry
 
     # @api private
     class Set
+      extend Forwardable
+      delegate [:each, :map] => :all
+
       def define(attributes)
         Transfer.new(attributes).tap do |transfer|
           key = [transfer.from, transfer.to, transfer.code]
@@ -47,8 +52,8 @@ module DoubleEntry
         end
       end
 
-      def each(&block)
-        backing_collection.values.each(&block)
+      def all
+        backing_collection.values
       end
 
     private

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -47,6 +47,10 @@ module DoubleEntry
         end
       end
 
+      def each(&block)
+        backing_collection.values.each(&block)
+      end
+
     private
 
       def backing_collection

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -66,11 +66,28 @@ module DoubleEntry
     end
 
     describe Account::Set do
-      describe '#define' do
-        context "given a 'savings' account is defined" do
-          before { subject.define(:identifier => 'savings') }
-          its(:first) { should be_an Account }
-          its('first.identifier') { should eq 'savings' }
+      subject(:set) { described_class.new }
+
+      describe '#find' do
+        before do
+          set.define(:identifier => :savings)
+          set.define(:identifier => :checking, :scope_identifier => ar_class)
+        end
+
+        let(:ar_class) { double(:ar_class) }
+
+        it 'finds unscoped accounts' do
+          expect(set.find(:savings, false)).to be_an Account
+          expect(set.find(:savings, false).identifier).to eq :savings
+
+          expect { set.find(:savings, true) }.to raise_error
+        end
+
+        it 'finds scoped accounts' do
+          expect(set.find(:checking, true)).to be_an Account
+          expect(set.find(:checking, true).identifier).to eq :checking
+
+          expect { set.find(:checking, false) }.to raise_error
         end
       end
 

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -80,14 +80,14 @@ module DoubleEntry
           expect(set.find(:savings, false)).to be_an Account
           expect(set.find(:savings, false).identifier).to eq :savings
 
-          expect { set.find(:savings, true) }.to raise_error
+          expect { set.find(:savings, true) }.to raise_error(UnknownAccount)
         end
 
         it 'finds scoped accounts' do
           expect(set.find(:checking, true)).to be_an Account
           expect(set.find(:checking, true).identifier).to eq :checking
 
-          expect { set.find(:checking, false) }.to raise_error
+          expect { set.find(:checking, false) }.to raise_error(UnknownAccount)
         end
       end
 

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -98,18 +98,28 @@ module DoubleEntry
     end
 
     describe Transfer::Set do
-      describe '#define' do
+      subject(:set) { described_class.new }
+
+      describe '#find' do
         before do
-          subject.define(
-            :code => 'code',
-            :from => double(:identifier => 'from'),
-            :to   => double(:identifier => 'to'),
+          set.define(
+            :code => :transfer_code,
+            :from => from_account.identifier,
+            :to   => to_account.identifier,
           )
         end
-        its(:first) { should be_a Transfer }
-        its('first.code') { should eq 'code' }
-        its('first.from.identifier') { should eq 'from' }
-        its('first.to.identifier') { should eq 'to' }
+
+        let(:from_account) { instance_double(Account, :identifier => :from) }
+        let(:to_account)   { instance_double(Account, :identifier => :to) }
+
+        subject { set.find(from_account, to_account, :transfer_code) }
+
+        it 'should find the transfer' do
+          expect(subject).to be_a Transfer
+          expect(subject.code).to eq :transfer_code
+          expect(subject.from).to eq from_account.identifier
+          expect(subject.to).to eq to_account.identifier
+        end
       end
     end
   end

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -100,25 +100,65 @@ module DoubleEntry
     describe Transfer::Set do
       subject(:set) { described_class.new }
 
+      before do
+        set.define(
+          :code => :transfer_code,
+          :from => from_account.identifier,
+          :to   => to_account.identifier,
+        )
+
+        set.define(
+          :code => :another_transfer_code,
+          :from => from_account.identifier,
+          :to   => to_account.identifier,
+        )
+      end
+
+      let(:from_account) { instance_double(Account, :identifier => :from) }
+      let(:to_account)   { instance_double(Account, :identifier => :to) }
+
       describe '#find' do
-        before do
-          set.define(
-            :code => :transfer_code,
-            :from => from_account.identifier,
-            :to   => to_account.identifier,
-          )
+        it 'should find the transfers' do
+          first_transfer = set.find(from_account, to_account, :transfer_code)
+          second_transfer = set.find(from_account, to_account, :another_transfer_code)
+
+          expect(first_transfer).to be_a Transfer
+          expect(first_transfer.code).to eq :transfer_code
+          expect(first_transfer.from).to eq from_account.identifier
+          expect(first_transfer.to).to eq to_account.identifier
+
+          expect(second_transfer).to be_a Transfer
+          expect(second_transfer.code).to eq :another_transfer_code
+          expect(second_transfer.from).to eq from_account.identifier
+          expect(second_transfer.to).to eq to_account.identifier
         end
 
-        let(:from_account) { instance_double(Account, :identifier => :from) }
-        let(:to_account)   { instance_double(Account, :identifier => :to) }
+        it 'should return nothing when searching for undefined transfers' do
+          undefined_transfer = set.find(to_account, from_account, :transfer_code)
 
-        subject { set.find(from_account, to_account, :transfer_code) }
+          expect(undefined_transfer).to eq nil
+        end
+      end
 
-        it 'should find the transfer' do
-          expect(subject).to be_a Transfer
-          expect(subject.code).to eq :transfer_code
-          expect(subject.from).to eq from_account.identifier
-          expect(subject.to).to eq to_account.identifier
+      describe '#find!' do
+        it 'should also find the transfers' do
+          first_transfer = set.find!(from_account, to_account, :transfer_code)
+          second_transfer = set.find!(from_account, to_account, :another_transfer_code)
+
+          expect(first_transfer).to be_a Transfer
+          expect(first_transfer.code).to eq :transfer_code
+          expect(first_transfer.from).to eq from_account.identifier
+          expect(first_transfer.to).to eq to_account.identifier
+
+          expect(second_transfer).to be_a Transfer
+          expect(second_transfer.code).to eq :another_transfer_code
+          expect(second_transfer.from).to eq from_account.identifier
+          expect(second_transfer.to).to eq to_account.identifier
+        end
+
+        it 'should raise an error when searching for undefined transfers' do
+          expect { set.find!(to_account, from_account, :transfer_code) }
+            .to raise_error(TransferNotAllowed)
         end
       end
     end

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -118,7 +118,7 @@ module DoubleEntry
       let(:to_account)   { instance_double(Account, :identifier => :to) }
 
       describe '#find' do
-        it 'should find the transfers' do
+        it 'finds the transfers' do
           first_transfer = set.find(from_account, to_account, :transfer_code)
           second_transfer = set.find(from_account, to_account, :another_transfer_code)
 
@@ -133,7 +133,7 @@ module DoubleEntry
           expect(second_transfer.to).to eq to_account.identifier
         end
 
-        it 'should return nothing when searching for undefined transfers' do
+        it 'returns nothing when searching for undefined transfers' do
           undefined_transfer = set.find(to_account, from_account, :transfer_code)
 
           expect(undefined_transfer).to eq nil
@@ -141,7 +141,7 @@ module DoubleEntry
       end
 
       describe '#find!' do
-        it 'should also find the transfers' do
+        it 'also finds the transfers' do
           first_transfer = set.find!(from_account, to_account, :transfer_code)
           second_transfer = set.find!(from_account, to_account, :another_transfer_code)
 
@@ -156,7 +156,7 @@ module DoubleEntry
           expect(second_transfer.to).to eq to_account.identifier
         end
 
-        it 'should raise an error when searching for undefined transfers' do
+        it 'raises an error when searching for undefined transfers' do
           expect { set.find!(to_account, from_account, :transfer_code) }
             .to raise_error(TransferNotAllowed)
         end


### PR DESCRIPTION
Every time we search for a particular transfer or account within their respective Sets, we iterate through all of them in an array - this change replaces both of these collections to use a Hash as the underlying datastore, allowing quick lookup.