### PR TITLE
Add contributor credits to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,20 @@ See the Github project [issues](https://github.com/envato/double_entry/issues).
 ## Contributors
 
 Many thanks to those who have contributed to both this gem, and the library upon which it was based, over the years:
-  * Ryan Allen - @ryan-allen
+  * Anthony Sellitti - @asellitt
   * Clinton Forbes - @clinton
-  * Vahid Ta'eed - @vahid
-  * Keith Pitt - @keithpitt
-  * Martin Spickermann - @spickermann
-  * Stephanie Staub - @stephnacios
   * Eaden McKee - @eadz
+  * Giancarlo Salamanca - @salamagd
+  * Jiexin Huang - @jiexinhuang
+  * Keith Pitt - @keithpitt
+  * Mark Turnley - @rabidcarrot
+  * Martin Jagusch - @MJIO
+  * Martin Spickermann - @spickermann
+  * Mary-Anne Cosgrove - @macosgrove
+  * Orien Madgwick - @orien
+  * Pete Yandall - @notahat
+  * Ryan Allen - @ryan-allen
   * Samuel Cochran - @sj26
+  * Stephanie Staub - @stephnacios
+  * Trung Lê - @joneslee85
+  * Vahid Ta'eed - @vahid

--- a/README.md
+++ b/README.md
@@ -303,3 +303,13 @@ See the Github project [issues](https://github.com/envato/double_entry/issues).
     ```sh
     bundle exec rake
     ```
+
+## Contributors
+
+Many thanks to those who have contributed to both this gem, and the library upon which it was based, over the years:
+  * Ryan Allen - @ryan-allen
+  * Keith Pitt - @keithpitt
+  * Martin Spickermann - @spickermann
+  * Stephanie Staub - @stephnacios
+  * Eaden McKee - @eadz
+  * Samuel Cochran - @sj26

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ See the Github project [issues](https://github.com/envato/double_entry/issues).
 
 Many thanks to those who have contributed to both this gem, and the library upon which it was based, over the years:
   * Ryan Allen - @ryan-allen
+  * Clinton Forbes - @clinton
+  * Vahid Ta'eed - @vahid
   * Keith Pitt - @keithpitt
   * Martin Spickermann - @spickermann
   * Stephanie Staub - @stephnacios

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -7,8 +7,8 @@ require 'double_entry/version'
 Gem::Specification.new do |gem|
   gem.name                  = 'double_entry'
   gem.version               = DoubleEntry::VERSION
-  gem.authors               = ['Anthony Sellitti', 'Keith Pitt', 'Martin Jagusch', 'Martin Spickermann', 'Mark Turnley', 'Orien Madgwick', 'Pete Yandall', 'Stephanie Staub', 'Giancarlo Salamanca']
-  gem.email                 = ['anthony.sellitti@envato.com', 'me@keithpitt.com', '_@mj.io', 'spickemann@gmail.com', 'mark@envato.com', '_@orien.io', 'pete@envato.com', 'staub.steph@gmail.com', 'giancarlo@salamanca.net.au']
+  gem.authors               = ['Anthony Sellitti', 'Martin Jagusch', 'Mark Turnley', 'Orien Madgwick', 'Pete Yandall', 'Giancarlo Salamanca']
+  gem.email                 = ['anthony.sellitti@envato.com', '_@mj.io', 'mark@envato.com', '_@orien.io', 'pete@envato.com', 'giancarlo@salamanca.net.au']
   gem.summary               = 'Tools to build your double entry financial ledger'
   gem.homepage              = 'https://github.com/envato/double_entry'
 

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -7,8 +7,8 @@ require 'double_entry/version'
 Gem::Specification.new do |gem|
   gem.name                  = 'double_entry'
   gem.version               = DoubleEntry::VERSION
-  gem.authors               = ['Anthony Sellitti', 'Martin Jagusch', 'Mark Turnley', 'Orien Madgwick', 'Pete Yandall', 'Giancarlo Salamanca']
-  gem.email                 = ['anthony.sellitti@envato.com', '_@mj.io', 'mark@envato.com', '_@orien.io', 'pete@envato.com', 'giancarlo@salamanca.net.au']
+  gem.authors               = ['Envato']
+  gem.email                 = ['rubygems@envato.com']
   gem.summary               = 'Tools to build your double entry financial ledger'
   gem.homepage              = 'https://github.com/envato/double_entry'
 


### PR DESCRIPTION
After discussions following #130, it was decided that Envato alumni that have contributed to this gem should be recognised for their work in the Readme file, while only current employees should be retained in the gemspec `authors` array, due to the permissions granted by being included in that list.