### PR TITLE
Resolve RSpec warning regarding false positive tests

### DIFF
--- a/spec/active_record/locking_extensions_spec.rb
+++ b/spec/active_record/locking_extensions_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
         expect(ActiveSupport::Notifications).
           to receive(:publish).
           with('deadlock_restart.double_entry', hash_including(:exception => exception))
-        expect { User.with_restart_on_deadlock { fail exception } }.to raise_error
+        expect { User.with_restart_on_deadlock { fail exception } }.to raise_error(ActiveRecord::RestartTransaction)
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
     it 'does not raise an error if a duplicate index error is raised in the database' do
       create(:user, username: 'keith')
 
-      expect { create(:user, username: 'keith') }.to raise_error
+      expect { create(:user, username: 'keith') }.to raise_error(ActiveRecord::RecordNotUnique)
       expect { User.create_ignoring_duplicates! :username => 'keith' }.to_not raise_error
     end
 

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DoubleEntry::Line do
 
       context 'given code = nil' do
         let(:code) { nil }
-        specify { expect { line_to_persist.save! }.to raise_error }
+        specify { expect { line_to_persist.save! }.to raise_error(ActiveRecord::NotNullViolation) }
       end
 
       context 'given account = :test, 54 ' do

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -31,7 +31,14 @@ RSpec.describe DoubleEntry::Line do
 
       context 'given code = nil' do
         let(:code) { nil }
-        specify { expect { line_to_persist.save! }.to raise_error(ActiveRecord::NotNullViolation) }
+        let(:expected_error) do
+          if defined?(ActiveRecord::NotNullViolation)
+            ActiveRecord::NotNullViolation
+          else
+            ActiveRecord::StatementInvalid
+          end
+        end
+        specify { expect { line_to_persist.save! }.to raise_error(expected_error) }
       end
 
       context 'given account = :test, 54 ' do


### PR DESCRIPTION
> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call.