### PR TITLE
Drop support for Ruby 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+ruby '>= 2.2.0'
 gemspec

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-its'
-  gem.add_development_dependency 'rspec-instafail'
   gem.add_development_dependency 'database_cleaner'
   gem.add_development_dependency 'generator_spec'
   gem.add_development_dependency 'factory_girl'

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables           = gem.files.grep(%r{bin/}).map { |f| File.basename(f) }
   gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths         = ['lib']
-  gem.required_ruby_version = '>= 2.1.0'
+  gem.required_ruby_version = '>= 2.2.0'
 
   gem.add_dependency 'money',                 '>= 6.0.0'
   gem.add_dependency 'activerecord',          '>= 3.2.0'


### PR DESCRIPTION
Official support for Ruby 2.1 ended on [2017-04-01](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/). Let's remove support for it in this gem.
 
Also remove unused development dependencies.