### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 before_install:
   - gem update --system
   - gem --version
+  - gem install bundler
 before_script:
   - cp spec/support/database.travis.yml spec/support/database.yml
   - mysql -e 'create database double_entry_test;'

--- a/spec/support/gemfiles/Gemfile.rails-4.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-4.2.x
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '../../../'
 
 gem 'rails', '~> 4.2.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3
+gem 'mysql2', '>= 0.3.13', '< 0.5'

--- a/spec/support/gemfiles/Gemfile.rails-5.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.0.x
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '../../../'
 
 gem 'rails', '~> 5.0.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4
+gem 'mysql2', '>= 0.3.18', '< 0.6.0'

--- a/spec/support/gemfiles/Gemfile.rails-5.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.1.x
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 gemspec :path => '../../../'
 
 gem 'rails', '~> 5.1.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4
+gem 'mysql2', '>= 0.3.18', '< 0.6.0'


### PR DESCRIPTION
The release of mysql2 v5 seems to have broken this build. Rails 4.2.10 doesn't allow this version and Bundler likes to install the latest version available. The fix is to add constraints identical to those imposed by Rails. I've added constraints for Rails 5.0 and 5.1 also. Hopefully this'll future proof the build a little.

There's also a problem with some Travis build agents running and old (defective) version of Bundler. I've added a step to install the latest release.