### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ script:
   - ruby script/jack_hammer -t 2000
 matrix:
   include:
-    - rvm: 2.2
-      gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
-      env: DB=mysql
     - rvm: 2.3
       gemfile: spec/support/gemfiles/Gemfile.rails-4.2.x
       env: DB=mysql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-- Removed support for Ruby 1.9, 2.0 and 2.1.
+- Removed support for Ruby 1.9, 2.0, 2.1 and 2.2.
 
 - Removed support for Rails 3.2, 4.0, and 4.1.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ DoubleEntry uses the [Money gem](https://github.com/RubyMoney/money) to encapsul
 DoubleEntry is tested against:
 
 Ruby
- * 2.2.x
  * 2.3.x
  * 2.4.x
  * 2.5.x


### PR DESCRIPTION
Ruby 2.2 is unmaintained as of March 2018. Let's stop testing this gem on this version of Ruby.