### PR TITLE
Don't include specs and scripts in gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Removed unneeded development dependencies from Gemspec.
 
+- Removed spec and script files from gem package.
+
 ### Fixed
 
 - Fixed more Ruby warnings.

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |gem|
   gem.summary               = 'Tools to build your double entry financial ledger'
   gem.homepage              = 'https://github.com/envato/double_entry'
 
-  gem.files                 = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  gem.executables           = gem.files.grep(%r{bin/}).map { |f| File.basename(f) }
-  gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
+  gem.files                 = `git ls-files -z`.split("\x0").select do |f|
+    f.match(%r{^(?:double_entry.gemspec|README|LICENSE|CHANGELOG|lib/)})
+  end
   gem.require_paths         = ['lib']
   gem.required_ruby_version = '>= 2.2.0'
 


### PR DESCRIPTION
Reduces the `double_entry.gem` file size from 54K to 29K.