### PR TITLE
Loosen column length constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `DoubleEntry::Reporting::AggregateArray::new`
   - `DoubleEntry::Reporting::LineAggregateFilter::new`
 
+- Loosened database string column contstraints to the default (255 characters).
+  Engineering teams can choose to apply this change, or apply their own column
+  length constraints specific to their needs. ([#152])
+
+- Removed default values for the length checks on `code`, `account` and `scope`
+  ([#152]). These checks will now only be performed when configured with a value:
+
+   ```ruby
+   DoubleEntry.configure do |config|
+     config.code_max_length = 47
+     config.account_identifier_max_length = 31
+     config.scope_identifier_max_length = 23
+   end
+   ```
+
 ### Removed
 
 - Removed support for Ruby 1.9, 2.0, 2.1 and 2.2.
@@ -76,6 +91,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `ActiveSupport::Notifications`.
 
 - Fixed problem of Rails version number not being set in migration template for apps using Rails 5 or higher.
+
+[#152]: https://github.com/envato/double_entry/pull/152
 
 ## [1.0.1] - 2018-01-06
 

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -4,21 +4,12 @@ require 'forwardable'
 module DoubleEntry
   class Account
     class << self
-      attr_writer :accounts, :scope_identifier_max_length, :account_identifier_max_length
+      attr_accessor :scope_identifier_max_length, :account_identifier_max_length
+      attr_writer :accounts
 
       # @api private
       def accounts
         @accounts ||= Set.new
-      end
-
-      # @api private
-      def scope_identifier_max_length
-        @scope_identifier_max_length ||= 23
-      end
-
-      # @api private
-      def account_identifier_max_length
-        @account_identifier_max_length ||= 31
       end
 
       # @api private
@@ -160,7 +151,7 @@ module DoubleEntry
 
       def ensure_scope_is_valid
         identity = scope_identity
-        if identity && identity.length > Account.scope_identifier_max_length
+        if identity && Account.scope_identifier_max_length && identity.length > Account.scope_identifier_max_length
           fail ScopeIdentifierTooLongError,
                "scope identifier '#{identity}' is too long. Please limit it to #{Account.scope_identifier_max_length} characters."
         end
@@ -175,7 +166,7 @@ module DoubleEntry
       @positive_only = args[:positive_only]
       @negative_only = args[:negative_only]
       @currency = args[:currency] || Money.default_currency
-      if identifier.length > Account.account_identifier_max_length
+      if Account.account_identifier_max_length && identifier.length > Account.account_identifier_max_length
         fail AccountIdentifierTooLongError,
              "account identifier '#{identifier}' is too long. Please limit it to #{Account.account_identifier_max_length} characters."
       end

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -4,16 +4,12 @@ require 'forwardable'
 module DoubleEntry
   class Transfer
     class << self
-      attr_writer :transfers, :code_max_length
+      attr_accessor :code_max_length
+      attr_writer :transfers
 
       # @api private
       def transfers
         @transfers ||= Set.new
-      end
-
-      # @api private
-      def code_max_length
-        @code_max_length ||= 47
       end
 
       # @api private
@@ -73,7 +69,7 @@ module DoubleEntry
       @code = attributes[:code]
       @from = attributes[:from]
       @to = attributes[:to]
-      if code.length > Transfer.code_max_length
+      if Transfer.code_max_length && code.length > Transfer.code_max_length
         fail TransferCodeTooLongError,
              "transfer code '#{code}' is too long. Please limit it to #{Transfer.code_max_length} characters."
       end

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -1,27 +1,27 @@
 class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
   def self.up
     create_table "double_entry_account_balances", :force => true do |t|
-      t.string     "account", :limit => 31, :null => false
-      t.string     "scope",   :limit => 23
-      t.integer    "balance",               :null => false
-      t.timestamps                          :null => false
+      t.string     "account", :null => false
+      t.string     "scope"
+      t.integer    "balance", :null => false
+      t.timestamps            :null => false
     end
 
     add_index "double_entry_account_balances", ["account"],          :name => "index_account_balances_on_account"
     add_index "double_entry_account_balances", ["scope", "account"], :name => "index_account_balances_on_scope_and_account", :unique => true
 
     create_table "double_entry_lines", :force => true do |t|
-      t.string     "account",         :limit => 31, :null => false
-      t.string     "scope",           :limit => 23
-      t.string     "code",            :limit => 47, :null => false
-      t.integer    "amount",                        :null => false
-      t.integer    "balance",                       :null => false
+      t.string     "account",         :null => false
+      t.string     "scope"
+      t.string     "code",            :null => false
+      t.integer    "amount",          :null => false
+      t.integer    "balance",         :null => false
       t.integer    "partner_id"
-      t.string     "partner_account", :limit => 31, :null => false
-      t.string     "partner_scope",   :limit => 23
+      t.string     "partner_account", :null => false
+      t.string     "partner_scope"
       t.integer    "detail_id"
       t.string     "detail_type"
-      t.timestamps                                  :null => false
+      t.timestamps                    :null => false
     end
 
     add_index "double_entry_lines", ["account", "code", "created_at"],  :name => "lines_account_code_created_at_idx"
@@ -31,9 +31,9 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
 
     create_table "double_entry_line_aggregates", :force => true do |t|
       t.string     "function",   :limit => 15, :null => false
-      t.string     "account",    :limit => 31, :null => false
-      t.string     "code",       :limit => 47
-      t.string     "scope",      :limit => 23
+      t.string     "account",                  :null => false
+      t.string     "code"
+      t.string     "scope"
       t.integer    "year"
       t.integer    "month"
       t.integer    "week"
@@ -51,16 +51,16 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.integer    "last_line_id", :null => false
       t.boolean    "errors_found", :null => false
       t.text       "log"
-      t.timestamps                             :null => false
+      t.timestamps                 :null => false
     end
 
     add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
 
     create_table "double_entry_line_metadata", :force => true do |t|
-      t.integer    "line_id",               :null => false
-      t.string     "key",     :limit => 48, :null => false
-      t.string     "value",   :limit => 64, :null => false
-      t.timestamps                          :null => false
+      t.integer    "line_id", :null => false
+      t.string     "key",     :null => false
+      t.string     "value",   :null => false
+      t.timestamps            :null => false
     end
 
     add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -4,17 +4,22 @@ module DoubleEntry
     let(:identity_scope) { ->(value) { value } }
 
     describe '::new' do
-      context 'given an identifier 31 characters in length' do
-        let(:identifier) { 'xxxxxxxx 31 characters xxxxxxxx' }
-        specify do
-          expect { Account.new(:identifier => identifier) }.to_not raise_error
-        end
-      end
+      context 'given a account_identifier_max_length of 31' do
+        before { Account.account_identifier_max_length = 31 }
+        after { Account.account_identifier_max_length = nil }
 
-      context 'given an identifier 32 characters in length' do
-        let(:identifier) { 'xxxxxxxx 32 characters xxxxxxxxx' }
-        specify do
-          expect { Account.new(:identifier => identifier) }.to raise_error AccountIdentifierTooLongError, /'#{identifier}'/
+        context 'given an identifier 31 characters in length' do
+          let(:identifier) { 'xxxxxxxx 31 characters xxxxxxxx' }
+          specify do
+            expect { Account.new(:identifier => identifier) }.to_not raise_error
+          end
+        end
+
+        context 'given an identifier 32 characters in length' do
+          let(:identifier) { 'xxxxxxxx 32 characters xxxxxxxxx' }
+          specify do
+            expect { Account.new(:identifier => identifier) }.to raise_error AccountIdentifierTooLongError, /'#{identifier}'/
+          end
         end
       end
     end
@@ -41,14 +46,19 @@ module DoubleEntry
         let(:account) { Account.new(:identifier => 'x', :scope_identifier => identity_scope) }
         subject(:initialize_account_instance) { Account::Instance.new(:account => account, :scope => scope) }
 
-        context 'given a scope identifier 23 characters in length' do
-          let(:scope) { 'xxxx 23 characters xxxx' }
-          specify { expect { initialize_account_instance }.to_not raise_error }
-        end
+        context 'given a scope_identifier_max_length of 23' do
+          before { Account.scope_identifier_max_length = 23 }
+          after { Account.scope_identifier_max_length = nil }
 
-        context 'given a scope identifier 24 characters in length' do
-          let(:scope) { 'xxxx 24 characters xxxxx' }
-          specify { expect { initialize_account_instance }.to raise_error ScopeIdentifierTooLongError, /'#{scope}'/ }
+          context 'given a scope identifier 23 characters in length' do
+             let(:scope) { 'xxxx 23 characters xxxx' }
+             specify { expect { initialize_account_instance }.to_not raise_error }
+           end
+
+          context 'given a scope identifier 24 characters in length' do
+            let(:scope) { 'xxxx 24 characters xxxxx' }
+            specify { expect { initialize_account_instance }.to raise_error ScopeIdentifierTooLongError, /'#{scope}'/ }
+          end
         end
       end
     end

--- a/spec/double_entry/configuration_spec.rb
+++ b/spec/double_entry/configuration_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe DoubleEntry::Configuration do
 
   describe 'max lengths' do
     context 'given a max length has not been set' do
-      its(:code_max_length) { should be 47 }
-      its(:scope_identifier_max_length) { should be 23 }
-      its(:account_identifier_max_length) { should be 31 }
+      its(:code_max_length) { should be_nil }
+      its(:scope_identifier_max_length) { should be_nil }
+      its(:account_identifier_max_length) { should be_nil }
     end
 
     context 'given a code max length of 10 has been set' do

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -2,17 +2,22 @@
 module DoubleEntry
   RSpec.describe Transfer do
     describe '::new' do
-      context 'given a code 47 characters in length' do
-        let(:code) { 'xxxxxxxxxxxxxxxx 47 characters xxxxxxxxxxxxxxxx' }
-        specify do
-          expect { Transfer.new(:code => code) }.to_not raise_error
-        end
-      end
+      context 'given a code_max_length of 47' do
+        before { Transfer.code_max_length = 47 }
+        after { Transfer.code_max_length = nil }
 
-      context 'given a code 48 characters in length' do
-        let(:code) { 'xxxxxxxxxxxxxxxx 48 characters xxxxxxxxxxxxxxxxx' }
-        specify do
-          expect { Transfer.new(:code => code) }.to raise_error TransferCodeTooLongError, /'#{code}'/
+        context 'given a code 47 characters in length' do
+          let(:code) { 'xxxxxxxxxxxxxxxx 47 characters xxxxxxxxxxxxxxxx' }
+          specify do
+            expect { Transfer.new(:code => code) }.to_not raise_error
+          end
+        end
+
+        context 'given a code 48 characters in length' do
+          let(:code) { 'xxxxxxxxxxxxxxxx 48 characters xxxxxxxxxxxxxxxxx' }
+          specify do
+            expect { Transfer.new(:code => code) }.to raise_error TransferCodeTooLongError, /'#{code}'/
+          end
         end
       end
     end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -2,27 +2,27 @@ ActiveRecord::Schema.define do
   self.verbose = false
 
   create_table "double_entry_account_balances", :force => true do |t|
-    t.string     "account", :limit => 31, :null => false
-    t.string     "scope",   :limit => 23
-    t.integer    "balance",               :null => false
-    t.timestamps                          :null => false
+    t.string     "account", :null => false
+    t.string     "scope"
+    t.integer    "balance", :null => false
+    t.timestamps            :null => false
   end
 
   add_index "double_entry_account_balances", ["account"],          :name => "index_account_balances_on_account"
   add_index "double_entry_account_balances", ["scope", "account"], :name => "index_account_balances_on_scope_and_account", :unique => true
 
   create_table "double_entry_lines", :force => true do |t|
-    t.string     "account",         :limit => 31, :null => false
-    t.string     "scope",           :limit => 23
-    t.string     "code",            :limit => 47, :null => false
-    t.integer    "amount",                        :null => false
-    t.integer    "balance",                       :null => false
+    t.string     "account",         :null => false
+    t.string     "scope"
+    t.string     "code",            :null => false
+    t.integer    "amount",          :null => false
+    t.integer    "balance",         :null => false
     t.integer    "partner_id"
-    t.string     "partner_account", :limit => 31, :null => false
-    t.string     "partner_scope",   :limit => 23
+    t.string     "partner_account", :null => false
+    t.string     "partner_scope"
     t.integer    "detail_id"
     t.string     "detail_type"
-    t.timestamps                                  :null => false
+    t.timestamps                    :null => false
   end
 
   add_index "double_entry_lines", ["account", "code", "created_at", "partner_account"],  :name => "lines_account_code_created_at_partner_account_idx"
@@ -32,10 +32,10 @@ ActiveRecord::Schema.define do
 
   create_table "double_entry_line_aggregates", :force => true do |t|
     t.string     "function",        :limit => 15, :null => false
-    t.string     "account",         :limit => 31, :null => false
-    t.string     "code",            :limit => 47
-    t.string     "partner_account", :limit => 31
-    t.string     "scope",           :limit => 23
+    t.string     "account",                       :null => false
+    t.string     "code"
+    t.string     "partner_account"
+    t.string     "scope"
     t.integer    "year"
     t.integer    "month"
     t.integer    "week"
@@ -59,10 +59,10 @@ ActiveRecord::Schema.define do
   add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
 
   create_table "double_entry_line_metadata", :force => true do |t|
-    t.integer    "line_id",               :null => false
-    t.string     "key",     :limit => 48, :null => false
-    t.string     "value",   :limit => 64, :null => false
-    t.timestamps                          :null => false
+    t.integer    "line_id", :null => false
+    t.string     "key",     :null => false
+    t.string     "value",   :null => false
+    t.timestamps            :null => false
   end
 
   add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"


### PR DESCRIPTION
Resolves #145 

### Context

The default database schema provided by DoubleEntry had small column length limits. These values were specific to the optimisations made on a specific project at Envato. As this project is open source and in use under vastly different use cases, these constraints limit the project effectiveness at satisfying these use cases.

### Change

1. Remove the column length constraints from the database migration template. DoubleEntry will operate correctly no matter the size of these columns.

2. Remove the default value for the `scope_identifier_max_length`, `account_identifier_max_length` and `code_max_length` configuration values. The checks will not be performed during account and transfer configuration unless these are options are set.

   ```ruby
   DoubleEntry.configure do |config|
     config.code_max_length = 47
     config.account_identifier_max_length = 31
     config.scope_identifier_max_length = 23
   end
   ```

MySQL 5.6 schema diff on Rails 5.2 looks like this:
```diff
43,44c43,44
<   `account` varchar(31) NOT NULL,
<   `scope` varchar(23) DEFAULT NULL,
---
>   `account` varchar(255) NOT NULL,
>   `scope` varchar(255) DEFAULT NULL,
64,67c64,67
<   `account` varchar(31) NOT NULL,
<   `code` varchar(47) DEFAULT NULL,
<   `partner_account` varchar(31) DEFAULT NULL,
<   `scope` varchar(23) DEFAULT NULL,
---
>   `account` varchar(255) NOT NULL,
>   `code` varchar(255) DEFAULT NULL,
>   `partner_account` varchar(255) DEFAULT NULL,
>   `scope` varchar(255) DEFAULT NULL,
112,113c112,113
<   `key` varchar(48) NOT NULL,
<   `value` varchar(64) NOT NULL,
---
>   `key` varchar(255) NOT NULL,
>   `value` varchar(255) NOT NULL,
130,132c130,132
<   `account` varchar(31) NOT NULL,
<   `scope` varchar(23) DEFAULT NULL,
<   `code` varchar(47) NOT NULL,
---
>   `account` varchar(255) NOT NULL,
>   `scope` varchar(255) DEFAULT NULL,
>   `code` varchar(255) NOT NULL,
136,137c136,137
<   `partner_account` varchar(31) NOT NULL,
<   `partner_scope` varchar(23) DEFAULT NULL,
---
>   `partner_account` varchar(255) NOT NULL,
>   `partner_scope` varchar(255) DEFAULT NULL,
```

To apply this change a migration similar to the following could be used:

```ruby
change_column :double_entry_account_balances, :account, :string, limit: 255, null: false
change_column :double_entry_account_balances, :scope,   :string, limit: 255, null: true

change_column :double_entry_line_aggregates, :account,         :string, limit: 255, null: false
change_column :double_entry_line_aggregates, :code,            :string, limit: 255, null: true
change_column :double_entry_line_aggregates, :partner_account, :string, limit: 255, null: true
change_column :double_entry_line_aggregates, :scope,           :string, limit: 255, null: true

change_column :double_entry_line_metadata, :key,   :string, limit: 255, null: false
change_column :double_entry_line_metadata, :value, :string, limit: 255, null: false

change_column :double_entry_lines, :account,         :string, limit: 255, null: false
change_column :double_entry_lines, :scope,           :string, limit: 255, null: true
change_column :double_entry_lines, :code,            :string, limit: 255, null: false
change_column :double_entry_lines, :partner_account, :string, limit: 255, null: false
change_column :double_entry_lines, :partner_scope,   :string, limit: 255, null: true
```

Engineering teams can choose to apply this change, or apply their own column length constraints specific to their needs.