### PR TITLE
Remove active_record_scope_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Removed spec and script files from gem package.
 
+- Removed the `active_record_scope_identifier` method for configuring scoped accounts.
+
+    ```ruby
+    user_scope = accounts.active_record_scope_identifier(User)
+    ```
+
+  As a replacement, please define your own with a lambda:
+
+    ```ruby
+    user_scope = ->(user) do
+      raise 'not a User' unless user.class.name == 'User'
+      user.id
+    end
+    ```
+
 ### Fixed
 
 - Fixed more Ruby warnings.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ require 'double_entry'
 
 DoubleEntry.configure do |config|
   config.define_accounts do |accounts|
-    user_scope = accounts.active_record_scope_identifier(User)
+    user_scope = ->(user) do
+      raise 'not a User' unless user.class.name == 'User'
+      user.id
+    end
     accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
     accounts.define(:identifier => :checking, :scope_identifier => user_scope)
   end

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -63,10 +63,6 @@ module DoubleEntry
         backing_collection[identifier]
       end
 
-      def active_record_scope_identifier(active_record_class)
-        ActiveRecordScopeFactory.new(active_record_class).scope_identifier
-      end
-
       def all
         backing_collection.values
       end
@@ -75,22 +71,6 @@ module DoubleEntry
 
       def backing_collection
         @backing_collection ||= Hash.new
-      end
-    end
-
-    class ActiveRecordScopeFactory
-      def initialize(active_record_class)
-        @active_record_class = active_record_class
-      end
-
-      def scope_identifier
-        lambda do |value|
-          if value.is_a?(@active_record_class)
-            value.id
-          else
-            fail AccountScopeMismatchError, "Expected instance of `#{@active_record_class}`, received instance of `#{value.class}`"
-          end
-        end
       end
     end
 

--- a/lib/double_entry/errors.rb
+++ b/lib/double_entry/errors.rb
@@ -12,5 +12,4 @@ module DoubleEntry
   class AccountWouldBeSentPositiveError < RuntimeError; end
   class MismatchedCurrencies < RuntimeError; end
   class MissingAccountError < RuntimeError; end
-  class AccountScopeMismatchError < RuntimeError; end
 end

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -90,62 +90,6 @@ module DoubleEntry
           expect { set.find(:checking, false) }.to raise_error(UnknownAccount)
         end
       end
-
-      describe '#active_record_scope_identifier' do
-        subject(:scope) { Account::Set.new.active_record_scope_identifier(ar_class) }
-
-        context 'given ActiveRecordScopeFactory is stubbed' do
-          let(:scope_identifier) { double(:scope_identifier) }
-          let(:scope_factory) { double(:scope_factory, :scope_identifier => scope_identifier) }
-          let(:ar_class) { double(:ar_class) }
-          before { allow(Account::ActiveRecordScopeFactory).to receive(:new).with(ar_class).and_return(scope_factory) }
-
-          it { should eq scope_identifier }
-        end
-      end
-    end
-  end
-
-  RSpec.describe Account::ActiveRecordScopeFactory do
-    context 'given the class User' do
-      subject(:factory) { Account::ActiveRecordScopeFactory.new(User) }
-
-      describe '#scope_identifier' do
-        subject(:scope_identifier) { factory.scope_identifier }
-
-        describe '#call' do
-          subject(:scope) { scope_identifier.call(value) }
-
-          context 'given a User instance with ID 32' do
-            let(:value) { build(:user, :id => 32) }
-
-            it { should eq 32 }
-          end
-
-          context 'given differing model instance with ID 32' do
-            let(:value) { double(:id => 32) }
-            it 'raises an error' do
-              expect { scope_identifier.call(value) }.to raise_error DoubleEntry::AccountScopeMismatchError
-            end
-          end
-
-          context "given the String 'I am a bearded lady'" do
-            let(:value) { 'I am a bearded lady' }
-
-            it 'raises an error' do
-              expect { scope_identifier.call(value) }.to raise_error DoubleEntry::AccountScopeMismatchError
-            end
-          end
-
-          context 'given the Integer 42' do
-            let(:value) { 42 }
-
-            it 'raises an error' do
-              expect { scope_identifier.call(value) }.to raise_error DoubleEntry::AccountScopeMismatchError
-            end
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
The `active_record_scope_identifier` method has been causing trouble in development environments for while, specifically when using Spring. See #115, #117, #144.

In essence account scope is just a function that transforms a business (or any) object to a scalar value to be stored in the database.

To promote flexibility and reduce the responsibilities of DoubleEntry gem we should just use a simple block.

For example, if we need to enforce the `savings` account be scoped to a `User` object we can define a block like this:

```ruby
user_scope = lambda do |user|
  raise 'account must be scoped by "User"' unless user.class.name == 'User'
  user.id
end
accounts.define(identifier: :savings,  scope_identifier: user_scope)
```

This allows projects to define solutions as best fit their needs and resolve problems as they arise.

Resolves #115