### PR TITLE
Use big (64bit) integers for monetary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
      config.scope_identifier_max_length = 23
    end
    ```
+- Use `bigint` for monetary values in the database to avoid integer overflow
+  ([#154]). Apply changes via this migration:
+
+   ```ruby
+   change_column :double_entry_account_balances, :balance, :bigint, null: false
+
+   change_column :double_entry_line_aggregates, :amount, :bigint, null: false
+
+   change_column :double_entry_lines, :amount, :bigint, null: false
+   change_column :double_entry_lines, :balance, :bigint, null: false
+   ```
+- On Rails version 5.1 and above, use `bigint` for foreign key values in the
+  database to avoid integer overflow ([#154]). Apply changes via this
+  migration:
+
+   ```ruby
+   change_column :double_entry_line_checks, :last_line_id, :bigint, null: false
+
+   change_column :double_entry_line_metadata, :line_id, :bigint, null: false
+
+   change_column :double_entry_lines, :partner_id, :bigint, null: true
+   change_column :double_entry_lines, :detail_id, :bigint, null: true
+   ```
 
 ### Removed
 
@@ -93,6 +116,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed problem of Rails version number not being set in migration template for apps using Rails 5 or higher.
 
 [#152]: https://github.com/envato/double_entry/pull/152
+[#154]: https://github.com/envato/double_entry/pull/154
 
 ## [1.0.1] - 2018-01-06
 

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -3,7 +3,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     create_table "double_entry_account_balances", :force => true do |t|
       t.string     "account", :null => false
       t.string     "scope"
-      t.integer    "balance", :null => false
+      t.bigint     "balance", :null => false
       t.timestamps            :null => false
     end
 
@@ -14,8 +14,8 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.string     "account",         :null => false
       t.string     "scope"
       t.string     "code",            :null => false
-      t.integer    "amount",          :null => false
-      t.integer    "balance",         :null => false
+      t.bigint     "amount",          :null => false
+      t.bigint     "balance",         :null => false
       t.references "partner",                         :index => false
       t.string     "partner_account", :null => false
       t.string     "partner_scope"
@@ -40,7 +40,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.integer    "week"
       t.integer    "day"
       t.integer    "hour"
-      t.integer    "amount",                   :null => false
+      t.bigint     "amount",                   :null => false
       t.string     "filter"
       t.string     "range_type", :limit => 15, :null => false
       t.timestamps                             :null => false

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -16,9 +16,10 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.string     "code",            :null => false
       t.integer    "amount",          :null => false
       t.integer    "balance",         :null => false
-      t.integer    "partner_id"
+      t.references "partner",                         :index => false
       t.string     "partner_account", :null => false
       t.string     "partner_scope"
+      t.references "detail",                          :index => false, :polymorphic => true
       t.integer    "detail_id"
       t.string     "detail_type"
       t.timestamps                    :null => false
@@ -48,7 +49,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     add_index "double_entry_line_aggregates", ["function", "account", "code", "year", "month", "week", "day"], :name => "line_aggregate_idx"
 
     create_table "double_entry_line_checks", :force => true do |t|
-      t.integer    "last_line_id", :null => false
+      t.references "last_line",    :null => false, :index => false
       t.boolean    "errors_found", :null => false
       t.text       "log"
       t.timestamps                 :null => false
@@ -57,7 +58,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
 
     create_table "double_entry_line_metadata", :force => true do |t|
-      t.integer    "line_id", :null => false
+      t.references "line",    :null => false, :index => false
       t.string     "key",     :null => false
       t.string     "value",   :null => false
       t.timestamps            :null => false

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -17,11 +17,10 @@ ActiveRecord::Schema.define do
     t.string     "code",            :null => false
     t.integer    "amount",          :null => false
     t.integer    "balance",         :null => false
-    t.integer    "partner_id"
+    t.references "partner",                         :index => false
     t.string     "partner_account", :null => false
     t.string     "partner_scope"
-    t.integer    "detail_id"
-    t.string     "detail_type"
+    t.references "detail",                          :index => false, :polymorphic => true
     t.timestamps                    :null => false
   end
 
@@ -50,7 +49,7 @@ ActiveRecord::Schema.define do
   add_index "double_entry_line_aggregates", ["function", "account", "code", "partner_account", "year", "month", "week", "day"], :name => "line_aggregate_idx"
 
   create_table "double_entry_line_checks", :force => true do |t|
-    t.integer    "last_line_id", :null => false
+    t.references "last_line",    :null => false, :index => false
     t.boolean    "errors_found", :null => false
     t.text       "log"
     t.timestamps                 :null => false
@@ -59,7 +58,7 @@ ActiveRecord::Schema.define do
   add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
 
   create_table "double_entry_line_metadata", :force => true do |t|
-    t.integer    "line_id", :null => false
+    t.references "line",    :null => false, :index => false
     t.string     "key",     :null => false
     t.string     "value",   :null => false
     t.timestamps            :null => false

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -4,7 +4,7 @@ ActiveRecord::Schema.define do
   create_table "double_entry_account_balances", :force => true do |t|
     t.string     "account", :null => false
     t.string     "scope"
-    t.integer    "balance", :null => false
+    t.bigint     "balance", :null => false
     t.timestamps            :null => false
   end
 
@@ -15,8 +15,8 @@ ActiveRecord::Schema.define do
     t.string     "account",         :null => false
     t.string     "scope"
     t.string     "code",            :null => false
-    t.integer    "amount",          :null => false
-    t.integer    "balance",         :null => false
+    t.bigint     "amount",          :null => false
+    t.bigint     "balance",         :null => false
     t.references "partner",                         :index => false
     t.string     "partner_account", :null => false
     t.string     "partner_scope"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define do
     t.integer    "week"
     t.integer    "day"
     t.integer    "hour"
-    t.integer    "amount",                        :null => false
+    t.bigint     "amount",                        :null => false
     t.string     "filter"
     t.string     "range_type",      :limit => 15, :null => false
     t.timestamps                                  :null => false


### PR DESCRIPTION
Use `bigint` for monetary values to avoid integer overflow. This increases the valid range of values from (-2<sup>31</sup> &#8211; 2<sup>31</sup>-1) to (-2<sup>63</sup> &#8211; 2<sup>63</sup>-1). That's a lot of money!



To update an existing installation, apply the following migration.

```ruby
change_column :double_entry_account_balances, :balance, :bigint, null: false

change_column :double_entry_line_aggregates, :amount, :bigint, null: false

change_column :double_entry_lines, :amount, :bigint, null: false
change_column :double_entry_lines, :balance, :bigint, null: false
```

Similarly, since version 5.1 Rails has started using `bigint` as the default type for ActiveRecord primary keys (`id` column). However, DoubleEntry specified its foreign keys as `integer`. Here we change that definition to use the Rails `references` helper. This'll match the type used by Rails: `integer` on Rails versions prior to 5.1, and `bigint` on 5.1 and above.

Use this migration to update the foreign keys. A similar migration can be used to update the primary keys.

```ruby
change_column :double_entry_line_checks, :last_line_id, :bigint, null: false

change_column :double_entry_line_metadata, :line_id, :bigint, null: false

change_column :double_entry_lines, :partner_id, :bigint, null: true
change_column :double_entry_lines, :detail_id, :bigint, null: true
```

A MySQL 5.6 schema diff on Rails 5.2 looks like this:
```diff
45c45
<   `balance` int(11) NOT NULL,
---
>   `balance` bigint(20) NOT NULL,
73c73
<   `amount` int(11) NOT NULL,
---
>   `amount` bigint(20) NOT NULL,
92c92
<   `last_line_id` int(11) NOT NULL,
---
>   `last_line_id` bigint(20) NOT NULL,
111c111
<   `line_id` int(11) NOT NULL,
---
>   `line_id` bigint(20) NOT NULL,
133,135c133,135
<   `amount` int(11) NOT NULL,
<   `balance` int(11) NOT NULL,
<   `partner_id` int(11) DEFAULT NULL,
---
>   `amount` bigint(20) NOT NULL,
>   `balance` bigint(20) NOT NULL,
>   `partner_id` bigint(20) DEFAULT NULL,
138d137
<   `detail_id` int(11) DEFAULT NULL,
139a139
>   `detail_id` bigint(20) DEFAULT NULL,
```

Fixes #113