### PR TITLE
Introduce DoubleEntryError superclass

### DIFF
--- a/lib/double_entry/errors.rb
+++ b/lib/double_entry/errors.rb
@@ -1,15 +1,16 @@
 # encoding: utf-8
 module DoubleEntry
-  class UnknownAccount < RuntimeError; end
-  class AccountIdentifierTooLongError < RuntimeError; end
-  class ScopeIdentifierTooLongError < RuntimeError; end
-  class TransferNotAllowed < RuntimeError; end
-  class TransferIsNegative < RuntimeError; end
-  class TransferCodeTooLongError < RuntimeError; end
-  class DuplicateAccount < RuntimeError; end
-  class DuplicateTransfer < RuntimeError; end
-  class AccountWouldBeSentNegative < RuntimeError; end
-  class AccountWouldBeSentPositiveError < RuntimeError; end
-  class MismatchedCurrencies < RuntimeError; end
-  class MissingAccountError < RuntimeError; end
+  class DoubleEntryError < RuntimeError; end
+  class UnknownAccount < DoubleEntryError; end
+  class AccountIdentifierTooLongError < DoubleEntryError; end
+  class ScopeIdentifierTooLongError < DoubleEntryError; end
+  class TransferNotAllowed < DoubleEntryError; end
+  class TransferIsNegative < DoubleEntryError; end
+  class TransferCodeTooLongError < DoubleEntryError; end
+  class DuplicateAccount < DoubleEntryError; end
+  class DuplicateTransfer < DoubleEntryError; end
+  class AccountWouldBeSentNegative < DoubleEntryError; end
+  class AccountWouldBeSentPositiveError < DoubleEntryError; end
+  class MismatchedCurrencies < DoubleEntryError; end
+  class MissingAccountError < DoubleEntryError; end
 end


### PR DESCRIPTION
Pull in the error class hierarchy change from #144 (thanks @KelseyDH).

By introducing a single superclass for all the specific DoubleEntry errors we allow clients to be more succinct in their error handling. They can define one way of handling all the specific errors Double Entry can raise:

```ruby
begin
  #…perform some DoubleEntry operations
rescue DoubleEntryError
  #…handle any DoubleEntry error raised
end
```


As `DoubleEntryError` inherits from `RuntimeError`, all our specific errors continue to inherit from `RuntimeError`. So this change is backwards compatible.