### PR TITLE
Resolve Money deprecations

### DIFF
--- a/spec/support/money.rb
+++ b/spec/support/money.rb
@@ -1,0 +1,1 @@
+Money.locale_backend = :i18n


### PR DESCRIPTION
Resolves these messages in the test suite output:

```
[DEPRECATION] `use_i18n` is deprecated - use `Money.locale_backend = :i18n` instead
```