### PR TITLE
Resolve FactoryBot deprecations

### DIFF
--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
     username { "user#{__id__}" }
 
     transient do
-      savings_balance false
-      checking_balance false
-      bitcoin_balance false
+      savings_balance { false }
+      checking_balance { false }
+      bitcoin_balance { false }
     end
 
     after(:create) do |user, evaluator|


### PR DESCRIPTION
Resolves these messages in the test suite output:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:
savings_balance { false }
To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:
rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```