### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -12,6 +12,13 @@ Gem::Specification.new do |gem|
   gem.summary               = 'Tools to build your double entry financial ledger'
   gem.homepage              = 'https://github.com/envato/double_entry'
 
+  gem.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/envato/double_entry/issues',
+    'changelog_uri'     => 'https://github.com/envato/double_entry/blob/master/CHANGELOG.md',
+    'documentation_uri' => 'https://www.rubydoc.info/github/envato/double_entry/',
+    'source_code_uri'   => 'https://github.com/envato/double_entry',
+  }
+
   gem.files                 = `git ls-files -z`.split("\x0").select do |f|
     f.match(%r{^(?:double_entry.gemspec|README|LICENSE|CHANGELOG|lib/)})
   end


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `mailing_list_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/double_entry after the next release.