### PR TITLE
Log an error to the DB if the cached balance is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     end
     ```
 
+- Log account balance cache errors to the database when performing the line check:
+  `DoubleEntry::Validation::LineCheck::perform!`
+
 ### Changed
 
 - Replaced Machinist with Factory Bot in test suite.

--- a/lib/double_entry/validation/line_check.rb
+++ b/lib/double_entry/validation/line_check.rb
@@ -91,12 +91,12 @@ module DoubleEntry
 
       def cached_balance_correct?(account, log)
         DoubleEntry.lock_accounts(account) do
-          account_balance_1 = AccountBalance.find_by_account(account).balance
-          account_balance_2 = account.balance
-          correct = (account_balance_1 == account_balance_2)
+          cached_balance = AccountBalance.find_by_account(account).balance
+          running_balance = account.balance
+          correct = (cached_balance == running_balance)
           log << <<~MESSAGE unless correct
             *********************************
-            Error on account #{account}: #{account_balance_1} (cached balance) != #{account_balance_2} (running balance)
+            Error on account #{account}: #{cached_balance} (cached balance) != #{running_balance} (running balance)
             *********************************
 
           MESSAGE

--- a/lib/double_entry/validation/line_check.rb
+++ b/lib/double_entry/validation/line_check.rb
@@ -96,7 +96,7 @@ module DoubleEntry
           correct = (account_balance_1 == account_balance_2)
           log << <<~MESSAGE unless correct
             *********************************
-            Error on account #{account} :: balance: #{account_balance_1} != #{account_balance_2}
+            Error on account #{account}: #{account_balance_1} (cached balance) != #{account_balance_2} (running balance)
             *********************************
 
           MESSAGE

--- a/spec/double_entry/validation/line_check_spec.rb
+++ b/spec/double_entry/validation/line_check_spec.rb
@@ -84,6 +84,9 @@ module DoubleEntry
             before { DoubleEntry::Line.order(:id).limit(1).update_all('balance = balance + 1') }
 
             its(:errors_found) { should eq true }
+            its(:log) { should include <<~LOG }
+              Error on account \#{Account account: btc_test scope:  currency: BTC} :: balance: -0.00010000 != -0.00009999
+            LOG
             it 'should correct the running balance' do
               expect { LineCheck.perform!  }.
                 to change { DoubleEntry::Line.order(:id).first.balance }.

--- a/spec/double_entry/validation/line_check_spec.rb
+++ b/spec/double_entry/validation/line_check_spec.rb
@@ -69,6 +69,10 @@ module DoubleEntry
 
             its(:errors_found) { should be true }
 
+            its(:log) { should include <<~LOG }
+              Error on account \#{Account account: savings scope:  currency: USD}: 100.01 (cached balance) != 100.00 (running balance)
+            LOG
+
             it 'should correct the account balance' do
               expect { LineCheck.perform!  }.
                 to change { DoubleEntry::AccountBalance.order(:id).first.balance }.
@@ -84,9 +88,11 @@ module DoubleEntry
             before { DoubleEntry::Line.order(:id).limit(1).update_all('balance = balance + 1') }
 
             its(:errors_found) { should eq true }
+
             its(:log) { should include <<~LOG }
-              Error on account \#{Account account: btc_test scope:  currency: BTC} :: balance: -0.00010000 != -0.00009999
+              Error on account \#{Account account: btc_test scope:  currency: BTC}: -0.00010000 (cached balance) != -0.00009999 (running balance)
             LOG
+
             it 'should correct the running balance' do
               expect { LineCheck.perform!  }.
                 to change { DoubleEntry::Line.order(:id).first.balance }.


### PR DESCRIPTION
The `DoubleEntry::Validation::LineCheck::perform!` process checks the running balance (in the `double_entry_lines` table) and cached balance (in the `double_entry_account_balances` table). If this process finds a calculation error in the running balance, it corrects the problem and records the incorrect calculation (in the `double_entry_line_checks` table). However, if it finds a calculation error in the cached balance, it will correct the calculation but not record a message.

### Change

Log account balance cache error messages to the database when performing the line check:
```ruby
DoubleEntry::Validation::LineCheck::perform!
```