### PR TITLE
Don't fix balance errors automatically by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    change_column :double_entry_lines, :detail_id, :bigint, null: true
    ```
 
+- Line check validation no-longer performs corrections by default. The
+  `DoubleEntry::Validation::LineCheck::perform!` method will only log validation
+  failures in the database. To perform auto-correction pass the `fixer` option:
+  `LineCheck.perform!(fixer: DoubleEntry::Validation::AccountFixer.new)`
+
 ### Removed
 
 - Removed support for Ruby 1.9, 2.0, 2.1 and 2.2.

--- a/lib/double_entry/validation.rb
+++ b/lib/double_entry/validation.rb
@@ -1,1 +1,2 @@
+require 'double_entry/validation/account_fixer'
 require 'double_entry/validation/line_check'

--- a/lib/double_entry/validation/account_fixer.rb
+++ b/lib/double_entry/validation/account_fixer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DoubleEntry
+  module Validation
+    class AccountFixer
+      def recalculate_account(account)
+        DoubleEntry.lock_accounts(account) do
+          recalculated_balance = Money.zero(account.currency)
+
+          lines_for_account(account).each do |line|
+            recalculated_balance += line.amount
+            if line.balance != recalculated_balance
+              line.update_attribute(:balance, recalculated_balance)
+            end
+          end
+
+          update_balance_for_account(account, recalculated_balance)
+        end
+      end
+
+      private
+
+      def lines_for_account(account)
+        Line.where(
+          account: account.identifier.to_s,
+          scope: account.scope_identity.to_s
+        ).order(:id)
+      end
+
+      def update_balance_for_account(account, balance)
+        account_balance = Locking.balance_for_locked_account(account)
+        account_balance.update_attribute(:balance, balance)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context 

The `DoubleEntry::Validation::LineCheck::perform!` process checks the running balance (in the `double_entry_lines` table) and cached balance (in the `double_entry_account_balances` table). If this process finds a calculation error in the running balance, it corrects the problem by locking the account in question (preventing new transactions on an incorrect balance) and then processing each line recorded, one-by-one recalculating the running balance. Considering that this recalculation process may take considerable time for accounts with millions of associated `double_entry_lines` rows, for some business cases it maybe unacceptable to prevent new transactions for the duration of the correction process.

### Change

Don't perform corrections by default. Instead just log the balance issues in the database. Teams can then plan for any required balance corrections using the new `AccountFixer` class:

```ruby
DoubleEntry::Validation::AccountFixer.new.recalculate_account(account)
```

If desired, the original automatic correction behaviour can be obtained by providing an `AccountFixer` instance to the line check process:

```ruby
DoubleEntry::Validation::LineCheck.perform!(
  fixer: DoubleEntry::Validation::AccountFixer.new
)
```