### PR TITLE
Move scopes_with_minimum_balance_for_account method to AccountBalance

### DIFF
--- a/lib/double_entry/account_balance.rb
+++ b/lib/double_entry/account_balance.rb
@@ -33,5 +33,22 @@ module DoubleEntry
       scope = scope.lock(true) if options[:lock]
       scope.first
     end
+
+    # Identify the scopes with the given account identifier holding at least
+    # the provided minimum balance.
+    #
+    # @example Find users with at least $1,000,000 in their savings accounts
+    #   DoubleEntry::AccountBalance.scopes_with_minimum_balance_for_account(
+    #     1_000_000.dollars,
+    #     :savings,
+    #   ) # might return the user ids: [ '1423', '12232', '34729' ]
+    # @param [Money] minimum_balance Minimum account balance a scope must have
+    #   to be included in the result set.
+    # @param [Symbol] account_identifier
+    # @return [Array<String>] Scopes
+    #
+    def self.scopes_with_minimum_balance_for_account(minimum_balance, account_identifier)
+      where(account: account_identifier).where('balance >= ?', minimum_balance.fractional).pluck(:scope)
+    end
   end
 end

--- a/lib/double_entry/reporting.rb
+++ b/lib/double_entry/reporting.rb
@@ -142,28 +142,6 @@ module DoubleEntry
                          filter: filter, range_type: range_type, start: start, finish: finish)
     end
 
-    # Identify the scopes with the given account identifier holding at least
-    # the provided minimum balance.
-    #
-    # @example Find users with at least $1,000,000 in their savings accounts
-    #   DoubleEntry::Reporting.scopes_with_minimum_balance_for_account(
-    #     1_000_000.dollars,
-    #     :savings,
-    #   ) # might return the user ids: [ 1423, 12232, 34729 ]
-    # @param [Money] minimum_balance Minimum account balance a scope must have
-    #   to be included in the result set.
-    # @param [Symbol] account_identifier
-    # @return [Array<Integer>] Scopes
-    #
-    def scopes_with_minimum_balance_for_account(minimum_balance, account_identifier)
-      select_values(sanitize_sql_array([<<-SQL, account_identifier, minimum_balance.cents])).map(&:to_i)
-        SELECT scope
-          FROM #{AccountBalance.table_name}
-         WHERE account = ?
-           AND balance >= ?
-      SQL
-    end
-
     # This is used by the concurrency test script.
     #
     # @api private

--- a/spec/double_entry/account_balance_spec.rb
+++ b/spec/double_entry/account_balance_spec.rb
@@ -4,4 +4,27 @@ RSpec.describe DoubleEntry::AccountBalance do
     subject { DoubleEntry::AccountBalance.table_name }
     it { should eq('double_entry_account_balances') }
   end
+
+  describe '.scopes_with_minimum_balance_for_account' do
+    subject(:scopes) { DoubleEntry::AccountBalance.scopes_with_minimum_balance_for_account(minimum_balance, :checking) }
+
+    context "a 'checking' account with balance $100" do
+      let!(:user) { create(:user, :checking_balance => Money.new(100_00)) }
+
+      context 'when searching for balance $99' do
+        let(:minimum_balance) { Money.new(99_00) }
+        it { should include user.id.to_s }
+      end
+
+      context 'when searching for balance $100' do
+        let(:minimum_balance) { Money.new(100_00) }
+        it { should include user.id.to_s }
+      end
+
+      context 'when searching for balance $101' do
+        let(:minimum_balance) { Money.new(101_00) }
+        it { should_not include user.id.to_s }
+      end
+    end
+  end
 end

--- a/spec/double_entry/reporting_spec.rb
+++ b/spec/double_entry/reporting_spec.rb
@@ -20,29 +20,6 @@ RSpec.describe DoubleEntry::Reporting do
     end
   end
 
-  describe '.scopes_with_minimum_balance_for_account' do
-    subject(:scopes) { DoubleEntry::Reporting.scopes_with_minimum_balance_for_account(minimum_balance, :checking) }
-
-    context "a 'checking' account with balance $100" do
-      let!(:user) { create(:user, :checking_balance => Money.new(100_00)) }
-
-      context 'when searching for balance $99' do
-        let(:minimum_balance) { Money.new(99_00) }
-        it { should include user.id }
-      end
-
-      context 'when searching for balance $100' do
-        let(:minimum_balance) { Money.new(100_00) }
-        it { should include user.id }
-      end
-
-      context 'when searching for balance $101' do
-        let(:minimum_balance) { Money.new(101_00) }
-        it { should_not include user.id }
-      end
-    end
-  end
-
   describe '.aggregate' do
     before do
       # get rid of "helpful" predefined config


### PR DESCRIPTION
The method `Reporting.scopes_with_minimum_balance_for_account` is a direct query on the `AccountBalance` active record model. I think the definition should live on that model. 

Minor change, the method now returns an array of `String` values rather than `Integer`s. This is more correct as scopes are defined and stored as strings and may not be integers in some account configurations.