### PR TITLE
Prepare for release: v2.0.0.beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.0.beta.1] - 2018-12-31
+
 ### Added
 
 - Added contributor credits to README.
@@ -344,7 +346,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Library released as Open Source!
 
-[Unreleased]: https://github.com/envato/double_entry/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/envato/double_entry/compare/v2.0.0.beta.1...HEAD
+[2.0.0.beta.1]: https://github.com/envato/double_entry/compare/v1.0.1...v2.0.0.beta.1
 [1.0.1]: https://github.com/envato/double_entry/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/envato/double_entry/compare/v0.10.3...v1.0.0
 [0.10.3]: https://github.com/envato/double_entry/compare/v0.10.2...v0.10.3

--- a/lib/double_entry/version.rb
+++ b/lib/double_entry/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module DoubleEntry
-  VERSION = '1.0.0'
+  VERSION = '2.0.0.beta.1'
 end


### PR DESCRIPTION
There's quite a lot of [unreleased changes](https://github.com/envato/double_entry/blob/master/CHANGELOG.md#unreleased) sitting on master including a few schema and minor API changes. Therefore, I propose to bump the major version on the next release: v2.0.0.

In this PR though, let's release a pre-release version. This'll give us the opportunity to perform some testing before the release proper.