### PR TITLE
Add license to the gem specification

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.email                 = ['rubygems@envato.com']
   gem.summary               = 'Tools to build your double entry financial ledger'
   gem.homepage              = 'https://github.com/envato/double_entry'
+  gem.license               = 'MIT'
 
   gem.metadata = {
     'bug_tracker_uri'   => 'https://github.com/envato/double_entry/issues',


### PR DESCRIPTION
After the next release this'll show up on the [project page](https://rubygems.org/gems/double_entry) on Rubygems.org.