### PR TITLE
Use version specific URIs in the gem metadata

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |gem|
 
   gem.metadata = {
     'bug_tracker_uri'   => 'https://github.com/envato/double_entry/issues',
-    'changelog_uri'     => 'https://github.com/envato/double_entry/blob/master/CHANGELOG.md',
-    'documentation_uri' => 'https://www.rubydoc.info/github/envato/double_entry/',
-    'source_code_uri'   => 'https://github.com/envato/double_entry',
+    'changelog_uri'     => "https://github.com/envato/double_entry/blob/v#{gem.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/double_entry/#{gem.version}",
+    'source_code_uri'   => "https://github.com/envato/double_entry/tree/v#{gem.version}",
   }
 
   gem.files                 = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
Aid developers by providing links to documentation specific to the version in use.