### PR TITLE
Fix the build

### DIFF
--- a/spec/support/gemfiles/Gemfile.rails-4.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-4.2.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '../../../'
 
-gem 'rails', '~> 4.2.0'
+gem 'activerecord', '~> 4.2.0'
 
 # Rails imposed mysql2 version contraints
 # https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3

--- a/spec/support/gemfiles/Gemfile.rails-5.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.0.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '../../../'
 
-gem 'rails', '~> 5.0.0'
+gem 'activerecord', '~> 5.0.0'
 
 # Rails imposed mysql2 version contraints
 # https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4

--- a/spec/support/gemfiles/Gemfile.rails-5.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.1.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '../../../'
 
-gem 'rails', '~> 5.1.0'
+gem 'activerecord', '~> 5.1.0'
 
 # Rails imposed mysql2 version contraints
 # https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4

--- a/spec/support/gemfiles/Gemfile.rails-5.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.2.x
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec :path => '../../../'
 
-gem 'rails', '~> 5.2.0'
+gem 'activerecord', '~> 5.2.0'
 
 # Rails imposed mysql2 version contraints
 # https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6


### PR DESCRIPTION
Bundler 2.0 has been released and is causing a bit of havoc in CI land. The Double Entry build [Rails 4.2 job](https://travis-ci.org/envato/double_entry/jobs/475083517) is failing due to it [installing Bundler 2.0](https://travis-ci.org/envato/double_entry/jobs/475083517#L1160), but Rails 4.2 only accepts [`>= 1.3.0, < 2.0`](https://travis-ci.org/envato/double_entry/jobs/475083517#L1172).

Actually, this constraint on Bundler is imposed by the Rails gem, which we don't actually need. Rather the gem depends on activerecord and activesupport. Let's reference that in our test Gemfiles.