### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ before_install:
   - gem update --system
   - gem --version
   - gem install bundler
+services:
+  - mysql
+  - postgresql
 before_script:
   - cp spec/support/database.travis.yml spec/support/database.yml
   - mysql -e 'create database double_entry_test;'


### PR DESCRIPTION
TravisCI now requires us to specify the services we need during the build.

DoubleEntry requires MySQL and PostgreSQL.