### PR TITLE
Remove duplicate detail fields in double_entry_lines table

### DIFF
--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -20,8 +20,6 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.string     "partner_account", :null => false
       t.string     "partner_scope"
       t.references "detail",                          :index => false, :polymorphic => true
-      t.integer    "detail_id"
-      t.string     "detail_type"
       t.timestamps                    :null => false
     end
 


### PR DESCRIPTION
Fixes problem described in issue #172.

Problem was introduced in #154.

I am unable to run the migration without this fix.