### PR TITLE
Prevent using Ruby 2.2 via restrictions in Gemfile and Gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Prevent using Ruby 2.2 via restrictions in Gemfile and Gemspec, ([#175]).
+
+[#175]: https://github.com/envato/double_entry/pull/175
+
 ## [2.0.0.beta3] - 2019-11-14
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-ruby '>= 2.2.0'
+ruby '>= 2.3.0'
 gemspec

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
     f.match(%r{^(?:double_entry.gemspec|README|LICENSE|CHANGELOG|lib/)})
   end
   gem.require_paths         = ['lib']
-  gem.required_ruby_version = '>= 2.2.0'
+  gem.required_ruby_version = '>= 2.3.0'
 
   gem.add_dependency 'activerecord',          '>= 3.2.0'
   gem.add_dependency 'activesupport',         '>= 3.2.0'


### PR DESCRIPTION
To prevent unexpected errors like in #174, let's prevent DoubleEntry from running on Ruby 2.2.