### PR TITLE
Store metadata by default in a json(b) column in the lines table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Metadata stored by default in a json(b) column for new installs ([#178]).
 - Test against Rails 6.0, ([#176]).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ bundle
 
 Generate Rails schema migrations for the required tables:
 
+> The default behavior is to store metadata in a json(b) column rather than a separate `double_entry_line_metadata` table. If you would like the old (1.x) behavior, you can add `--no-json-metadata`.
+
 ```sh
 rails generate double_entry:install
 ```
@@ -175,8 +177,7 @@ See **DoubleEntry::Line** for more info.
 AccountBalance records cache the current balance for each Account, and are used
 to perform database level locking.
 
-Transfer metadata is stored as key/value pairs associated with both the source and destination lines of the transfer.
-See **DoubleEntry::LineMetadata** for more info.
+Transfer metadata is stored in a json(b) column on both the source and destination lines of the transfer.
 
 ## Configuration
 
@@ -184,7 +185,7 @@ A configuration file should be used to define a set of accounts, optional scopes
 the accounts, and permitted transfers between those accounts.
 
 The configuration file should be kept in your application's load path.  For example,
-*config/initializers/double_entry.rb*
+*config/initializers/double_entry.rb*. By default, this file will be created when you run the installer, but you will need to fill out your accounts.
 
 For example, the following specifies two accounts, savings and checking.
 Each account is scoped by User (where User is an object with an ID), meaning
@@ -196,6 +197,9 @@ This configuration also specifies that money can be transferred between the two 
 require 'double_entry'
 
 DoubleEntry.configure do |config|
+  # Use json(b) column in double_entry_lines table to store metadata instead of separate metadata table
+  config.json_metadata = true
+
   config.define_accounts do |accounts|
     user_scope = ->(user) do
       raise 'not a User' unless user.class.name == 'User'
@@ -329,6 +333,7 @@ Many thanks to those who have contributed to both this gem, and the library upon
   * Rizal Muthi - @rizalmuthi
   * Ryan Allen - @ryan-allen
   * Samuel Cochran - @sj26
+  * Stefan Wrobel - @swrobel
   * Stephanie Staub - @stephnacios
   * Trung Lê - @joneslee85
   * Vahid Ta'eed - @vahid

--- a/lib/double_entry.rb
+++ b/lib/double_entry.rb
@@ -4,6 +4,7 @@ require 'active_record/locking_extensions'
 require 'active_record/locking_extensions/log_subscriber'
 require 'active_support/all'
 require 'money'
+require 'rails/railtie'
 
 require 'double_entry/version'
 require 'double_entry/errors'
@@ -14,8 +15,6 @@ require 'double_entry/account_balance'
 require 'double_entry/balance_calculator'
 require 'double_entry/locking'
 require 'double_entry/transfer'
-require 'double_entry/line'
-require 'double_entry/line_metadata'
 require 'double_entry/validation'
 
 # Keep track of all the monies!
@@ -23,6 +22,16 @@ require 'double_entry/validation'
 # This module provides the public interfaces for everything to do with
 # transferring money around the system.
 module DoubleEntry
+  class Railtie < ::Rails::Railtie
+    # So we can access user config from initializer in their app
+    config.after_initialize do
+      unless DoubleEntry.config.json_metadata
+        require 'double_entry/line_metadata'
+      end
+      require 'double_entry/line'
+    end
+  end
+
   class << self
     # Get the particular account instance with the provided identifier and
     # scope.

--- a/lib/double_entry/configurable.rb
+++ b/lib/double_entry/configurable.rb
@@ -41,6 +41,7 @@ module DoubleEntry
       def configuration
         @configuration ||= self::Configuration.new
       end
+      alias config configuration
 
       def configure
         yield(configuration)

--- a/lib/double_entry/configuration.rb
+++ b/lib/double_entry/configuration.rb
@@ -3,6 +3,12 @@ module DoubleEntry
   include Configurable
 
   class Configuration
+    attr_accessor :json_metadata
+
+    def initialize
+      @json_metadata = false
+    end
+
     delegate(
       :accounts,
       :accounts=,

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -56,7 +56,7 @@ module DoubleEntry
   #
   class Line < ActiveRecord::Base
     belongs_to :detail, :polymorphic => true
-    has_many :metadata, :class_name => 'DoubleEntry::LineMetadata'
+    has_many :metadata, :class_name => 'DoubleEntry::LineMetadata' unless -> { DoubleEntry.config.json_metadata }
     scope :with_id_greater_than, ->(id) { where('id > ?', id) }
 
     def amount

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -88,12 +88,12 @@ module DoubleEntry
         fail MismatchedCurrencies, "Mismatched currency (#{to_account.currency} <> #{from_account.currency})"
       end
       Locking.lock_accounts(from_account, to_account) do
-        credit, debit = create_lines(amount, code, detail, from_account, to_account)
-        create_line_metadata(credit, debit, metadata) if metadata
+        credit, debit = create_lines(amount, code, detail, from_account, to_account, metadata)
+        create_line_metadata(credit, debit, metadata) if metadata && !DoubleEntry.config.json_metadata
       end
     end
 
-    def create_lines(amount, code, detail, from_account, to_account)
+    def create_lines(amount, code, detail, from_account, to_account, metadata)
       credit, debit = Line.new, Line.new
 
       credit_balance = Locking.balance_for_locked_account(from_account)
@@ -107,6 +107,7 @@ module DoubleEntry
       credit.code, debit.code       = code, code
       credit.detail, debit.detail   = detail, detail
       credit.balance, debit.balance = credit_balance.balance, debit_balance.balance
+      credit.metadata, debit.metadata = metadata, metadata if DoubleEntry.config.json_metadata
 
       credit.partner_account, debit.partner_account = to_account, from_account
 

--- a/lib/generators/double_entry/install/install_generator.rb
+++ b/lib/generators/double_entry/install/install_generator.rb
@@ -7,6 +7,8 @@ module DoubleEntry
     class InstallGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
 
+      class_option :json_metadata, type: :boolean, default: true
+
       source_root File.expand_path('../templates', __FILE__)
 
       def self.next_migration_number(path)
@@ -15,6 +17,19 @@ module DoubleEntry
 
       def copy_migrations
         migration_template 'migration.rb', 'db/migrate/create_double_entry_tables.rb', migration_version: migration_version
+      end
+
+      def create_initializer
+        template 'initializer.rb', 'config/initializers/double_entry.rb'
+      end
+
+      def json_metadata
+        # MySQL JSON support added to AR 5.0
+        if ActiveRecord.version.version < '5'
+          false
+        else
+          options[:json_metadata]
+        end
       end
 
       def migration_version

--- a/lib/generators/double_entry/install/templates/initializer.rb
+++ b/lib/generators/double_entry/install/templates/initializer.rb
@@ -1,0 +1,20 @@
+require 'double_entry'
+
+DoubleEntry.configure do |config|
+  # Use json(b) column in double_entry_lines table to store metadata instead of separate metadata table
+  config.json_metadata = <%= json_metadata %>
+
+  # config.define_accounts do |accounts|
+  #   user_scope = ->(user) do
+  #     raise 'not a User' unless user.class.name == 'User'
+  #     user.id
+  #   end
+  #   accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
+  #   accounts.define(:identifier => :checking, :scope_identifier => user_scope)
+  # end
+  #
+  # config.define_transfers do |transfers|
+  #   transfers.define(:from => :checking, :to => :savings,  :code => :deposit)
+  #   transfers.define(:from => :savings,  :to => :checking, :code => :withdraw)
+  # end
+end

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -20,6 +20,13 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
       t.string     "partner_account", :null => false
       t.string     "partner_scope"
       t.references "detail",                          :index => false, :polymorphic => true
+      <%- if json_metadata -%>
+      if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+        t.jsonb "metadata"
+      else
+        t.json "metadata"
+      end
+      <%- end -%>
       t.timestamps                    :null => false
     end
 
@@ -36,6 +43,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     end
 
     add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
+    <%- unless json_metadata -%>
 
     create_table "double_entry_line_metadata", :force => true do |t|
       t.references "line",    :null => false, :index => false
@@ -45,10 +53,11 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     end
 
     add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
+    <%- end -%>
   end
 
   def self.down
-    drop_table "double_entry_line_metadata"
+    drop_table "double_entry_line_metadata" if table_exists?("double_entry_line_metadata")
     drop_table "double_entry_line_checks"
     drop_table "double_entry_lines"
     drop_table "double_entry_account_balances"

--- a/script/jack_hammer
+++ b/script/jack_hammer
@@ -31,6 +31,7 @@ require "#{support}/schema"
 lib = File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'double_entry'
+require 'double_entry/line'
 
 def parse_options
   $account_count       = 5

--- a/spec/double_entry/locking_spec.rb
+++ b/spec/double_entry/locking_spec.rb
@@ -2,15 +2,15 @@
 
 RSpec.describe DoubleEntry::Locking do
   before do
-    @config_accounts = DoubleEntry.configuration.accounts
-    @config_transfers = DoubleEntry.configuration.transfers
-    DoubleEntry.configuration.accounts = DoubleEntry::Account::Set.new
-    DoubleEntry.configuration.transfers = DoubleEntry::Transfer::Set.new
+    @config_accounts = DoubleEntry.config.accounts
+    @config_transfers = DoubleEntry.config.transfers
+    DoubleEntry.config.accounts = DoubleEntry::Account::Set.new
+    DoubleEntry.config.transfers = DoubleEntry::Transfer::Set.new
   end
 
   after do
-    DoubleEntry.configuration.accounts = @config_accounts
-    DoubleEntry.configuration.transfers = @config_transfers
+    DoubleEntry.config.accounts = @config_accounts
+    DoubleEntry.config.transfers = @config_transfers
   end
 
   before do

--- a/spec/double_entry_spec.rb
+++ b/spec/double_entry_spec.rb
@@ -3,15 +3,15 @@ RSpec.describe DoubleEntry do
   # these specs blat the DoubleEntry configuration, so take
   # a copy and clean up after ourselves
   before do
-    @config_accounts = DoubleEntry.configuration.accounts
-    @config_transfers = DoubleEntry.configuration.transfers
-    DoubleEntry.configuration.accounts = DoubleEntry::Account::Set.new
-    DoubleEntry.configuration.transfers = DoubleEntry::Transfer::Set.new
+    @config_accounts = DoubleEntry.config.accounts
+    @config_transfers = DoubleEntry.config.transfers
+    DoubleEntry.config.accounts = DoubleEntry::Account::Set.new
+    DoubleEntry.config.transfers = DoubleEntry::Transfer::Set.new
   end
 
   after do
-    DoubleEntry.configuration.accounts = @config_accounts
-    DoubleEntry.configuration.transfers = @config_transfers
+    DoubleEntry.config.accounts = @config_accounts
+    DoubleEntry.config.transfers = @config_transfers
   end
 
   describe 'configuration' do

--- a/spec/generators/double_entry/install/install_generator_spec.rb
+++ b/spec/generators/double_entry/install/install_generator_spec.rb
@@ -5,25 +5,130 @@ require 'generators/double_entry/install/install_generator'
 RSpec.describe DoubleEntry::Generators::InstallGenerator do
   include GeneratorSpec::TestCase
 
+  # Needed until a new release of generator_spec gem with https://github.com/stevehodgkiss/generator_spec/pull/47
+  module GeneratorSpec::Matcher
+    class Migration
+      def does_not_contain(text)
+        @does_not_contain << text
+      end
+
+      def check_contents(file)
+        contents = ::File.read(file)
+
+        @contents.each do |string|
+          unless contents.include?(string)
+            throw :failure, [file, string, contents]
+          end
+        end
+
+        @does_not_contain.each do |string|
+          if contents.include?(string)
+            throw :failure, [:not, file, string, contents]
+          end
+        end
+      end
+    end
+
+    class Root
+      def failure_message
+        if @failure.is_a?(Array) && @failure[0] == :not
+          if @failure.length > 2
+            "Structure should have #{@failure[1]} without #{@failure[2]}. It had:\n#{@failure[3]}"
+          else
+            "Structure should not have had #{@failure[1]}, but it did"
+          end
+        elsif @failure.is_a?(Array)
+          "Structure should have #{@failure[0]} with #{@failure[1]}. It had:\n#{@failure[2]}"
+        else
+          "Structure should have #{@failure}, but it didn't"
+        end
+      end
+    end
+  end
+
   destination File.expand_path('../../../../../tmp/generators', __FILE__)
 
   before do
     prepare_destination
-    run_generator
   end
 
-  it 'generates the expected migrations' do
+  def expect_migration_to_have_structure(&block)
     expect(destination_root).to have_structure {
       directory 'db' do
         directory 'migrate' do
           migration 'create_double_entry_tables' do
-            contains 'class CreateDoubleEntryTable'
+            @does_not_contain = []
+            contains 'class CreateDoubleEntryTables'
             contains 'create_table "double_entry_account_balances"'
             contains 'create_table "double_entry_lines"'
             contains 'create_table "double_entry_line_checks"'
+            instance_eval(&block)
           end
         end
       end
     }
+  end
+
+  RSpec.shared_examples 'with_json_metadata' do
+    it 'generates the expected migrations' do
+      expect_migration_to_have_structure do
+        contains 't.json "metadata"'
+        does_not_contain 'create_table "double_entry_line_metadata"'
+      end
+    end
+
+    it 'generates the expected initializer' do
+      expect(destination_root).to have_structure {
+        directory 'config' do
+          directory 'initializers' do
+            file 'double_entry.rb' do
+              contains 'config.json_metadata = true'
+            end
+          end
+        end
+      }
+    end
+  end
+
+  RSpec.shared_examples 'without_json_metadata' do
+    it 'generates the expected migrations' do
+      expect_migration_to_have_structure do
+        contains 'create_table "double_entry_line_metadata"'
+        contains 'add_index "double_entry_line_metadata"'
+        does_not_contain 't.json "metadata"'
+      end
+    end
+
+    it 'generates the expected initializer' do
+      expect(destination_root).to have_structure {
+        directory 'config' do
+          directory 'initializers' do
+            file 'double_entry.rb' do
+              contains 'config.json_metadata = false'
+            end
+          end
+        end
+      }
+    end
+  end
+
+  context 'without arguments' do
+    before { run_generator }
+
+    examples = ActiveRecord.version.version < '5' ? 'without_json_metadata' : 'with_json_metadata'
+    include_examples examples
+  end
+
+  context 'with --json-metadata' do
+    before { run_generator %w(--json-metadata) }
+
+    examples = ActiveRecord.version.version < '5' ? 'without_json_metadata' : 'with_json_metadata'
+    include_examples examples
+  end
+
+  context 'with --no-json-metadata' do
+    before { run_generator %w(--no-json-metadata) }
+
+    include_examples 'without_json_metadata'
   end
 end

--- a/spec/performance/double_entry_performance_spec.rb
+++ b/spec/performance/double_entry_performance_spec.rb
@@ -12,20 +12,29 @@ module DoubleEntry
         # local results: 6.44, 5.93, 5.94
       end
 
-      it 'creates a lot of transfers quickly with metadata' do
+      it 'creates a lot of transfers quickly with metadata & separate metadata table' do
         big_metadata = {}
         8.times { |i| big_metadata["key#{i}".to_sym] = "value#{i}" }
-        profile_transfers_with_metadata(big_metadata)
+        profile_transfers_with_metadata(big_metadata, 'transfer-with-metadata-table')
+        # local results: 21.2, 21.6, 20.9
+      end
+
+      it 'creates a lot of transfers quickly with metadata & metadata column on lines table', skip: ActiveRecord.version.version < '5' do
+        DoubleEntry.config.json_metadata = true
+        big_metadata = {}
+        8.times { |i| big_metadata["key#{i}".to_sym] = "value#{i}" }
+        profile_transfers_with_metadata(big_metadata, 'transfer-with-metadata-column')
+        DoubleEntry.config.json_metadata = false
         # local results: 21.2, 21.6, 20.9
       end
     end
 
-    def profile_transfers_with_metadata(metadata)
+    def profile_transfers_with_metadata(metadata, profile_name = nil)
       start_profiling
       options = { :from => test, :to => savings, :code => :bonus }
       options[:metadata] = metadata if metadata
       100.times { Transfer.transfer(amount, options) }
-      profile_name = metadata ? 'transfer-with-metadata' : 'transfer'
+      profile_name ||= 'transfer'
       stop_profiling(profile_name)
     end
   end

--- a/spec/support/line_metadata.rb
+++ b/spec/support/line_metadata.rb
@@ -1,0 +1,2 @@
+require 'double_entry/line_metadata'
+require 'double_entry/line'

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -21,6 +21,13 @@ ActiveRecord::Schema.define do
     t.string     "partner_account", :null => false
     t.string     "partner_scope"
     t.references "detail",                          :index => false, :polymorphic => true
+    unless ActiveRecord.version.version < '5'
+      if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
+        t.jsonb "metadata"
+      else
+        t.json "metadata"
+      end
+    end
     t.timestamps                    :null => false
   end
 


### PR DESCRIPTION
This is my attempt at improving performance of metadata storage by moving it from a separate key/value table into the lines table. The results of tests seem to show a substantial improvement on my machine:

```
Running tests with `DB=mysql`
transfer Time: 5.84s
transfer-with-metadata-table Time: 17.3s
transfer-with-metadata-column Time: 6.06s

Running tests with `DB=postgres`
transfer Time: 5.91s
transfer-with-metadata-table Time: 18.5s
transfer-with-metadata-column Time: 6.42s

Running tests with `DB=sqlite`
transfer Time: 6.20s
transfer-with-metadata-table Time: 17.2s
transfer-with-metadata-column Time: 6.02s
```

This is achieved via a default for new installs, which sets `config.json_metadata = true` in an initializer, which is also newly generated by the installer. The default value is `false`, so existing installs should work just fine with the old metadata table. I have tests in place for both scenarios.

It's worth noting that I haven't added any indexes on the metadata column. I know that for Postgres, efficient querying is possible using a [gin index](https://www.postgresql.org/docs/12/datatype-json.html#JSON-INDEXING). However I'm not sure about MySQL, and I honestly doubt it matters for SQLite since that's presumably just used for development. **I'd be interested in input on that subject.**