### PR TITLE
Remove force: true from create_table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Metadata stored by default in a json(b) column for new installs ([#178]).
 - Test against Rails 6.0, ([#176]).
 
-- Added support for Ruby 2.7 ([#180]).
+- Support for Ruby 2.7 ([#180]).
 
 ### Changed
 
-- Prevent using Ruby 2.2 via restrictions in Gemfile and Gemspec, ([#175]).
+- Metadata stored by default in a json(b) column for new installs ([#178]).
+
+- Remove `force: true` from migration ([#181]).
+
+- Prevent using Ruby 2.2 via restrictions in Gemfile and Gemspec ([#175]).
 
 [#175]: https://github.com/envato/double_entry/pull/175
 [#176]: https://github.com/envato/double_entry/pull/176
+[#178]: https://github.com/envato/double_entry/pull/178
 [#180]: https://github.com/envato/double_entry/pull/180
+[#181]: https://github.com/envato/double_entry/pull/181
 
 ## [2.0.0.beta3] - 2019-11-14
 

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -1,6 +1,6 @@
 class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
   def self.up
-    create_table "double_entry_account_balances", :force => true do |t|
+    create_table "double_entry_account_balances" do |t|
       t.string     "account", :null => false
       t.string     "scope"
       t.bigint     "balance", :null => false
@@ -10,7 +10,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     add_index "double_entry_account_balances", ["account"],          :name => "index_account_balances_on_account"
     add_index "double_entry_account_balances", ["scope", "account"], :name => "index_account_balances_on_scope_and_account", :unique => true
 
-    create_table "double_entry_lines", :force => true do |t|
+    create_table "double_entry_lines" do |t|
       t.string     "account",         :null => false
       t.string     "scope"
       t.string     "code",            :null => false
@@ -35,7 +35,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     add_index "double_entry_lines", ["scope", "account", "created_at"], :name => "lines_scope_account_created_at_idx"
     add_index "double_entry_lines", ["scope", "account", "id"],         :name => "lines_scope_account_id_idx"
 
-    create_table "double_entry_line_checks", :force => true do |t|
+    create_table "double_entry_line_checks" do |t|
       t.references "last_line",    :null => false, :index => false
       t.boolean    "errors_found", :null => false
       t.text       "log"
@@ -45,7 +45,7 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
     add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
     <%- unless json_metadata -%>
 
-    create_table "double_entry_line_metadata", :force => true do |t|
+    create_table "double_entry_line_metadata" do |t|
       t.references "line",    :null => false, :index => false
       t.string     "key",     :null => false
       t.string     "value",   :null => false


### PR DESCRIPTION
This seems to have been in the migration since the first commit, but I see no reason for it to be there (and it's generally considered unsafe, so it's better not to have it unless needed)

Context: this behavior is [flagged by strong_migrations](https://github.com/ankane/strong_migrations/blob/v0.5.1/lib/strong_migrations.rb#L136)