### PR TITLE
Remove unnecessary hashrockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ than scoped accounts due to lock contention.
 To get a particular account:
 
 ```ruby
-account = DoubleEntry.account(:spending, :scope => user)
+account = DoubleEntry.account(:spending, scope: user)
 ```
 
 (This actually returns an Account::Instance object.)
@@ -119,9 +119,9 @@ To transfer money between accounts:
 ```ruby
 DoubleEntry.transfer(
   Money.new(20_00),
-  :from => one_account,
-  :to   => another_account,
-  :code => :a_business_code_for_this_type_of_transfer,
+  from: one_account,
+  to:   another_account,
+  code: :a_business_code_for_this_type_of_transfer,
 )
 ```
 
@@ -136,10 +136,10 @@ You may associate arbitrary metadata with transfers, for example:
 ```ruby
 DoubleEntry.transfer(
   Money.new(20_00),
-  :from => one_account,
-  :to   => another_account,
-  :code => :a_business_code_for_this_type_of_transfer,
-  :metadata => {:key1 => ['value 1', 'value 2'], :key2 => 'value 3'},
+  from: one_account,
+  to:   another_account,
+  code: :a_business_code_for_this_type_of_transfer,
+  metadata: {key1: ['value 1', 'value 2'], key2: 'value 3'},
 )
 ```
 
@@ -152,7 +152,7 @@ manually lock the accounts you're using:
 ```ruby
 DoubleEntry.lock_accounts(account_a, account_b) do
   # Perhaps transfer some money
-  DoubleEntry.transfer(Money.new(20_00), :from => account_a, :to => account_b, :code => :purchase)
+  DoubleEntry.transfer(Money.new(20_00), from: account_a, to: account_b, code: :purchase)
   # Perform other tasks that should be commited atomically with the transfer of funds...
 end
 ```
@@ -206,13 +206,13 @@ DoubleEntry.configure do |config|
       raise 'not a User' unless user.class.name == 'User'
       user.id
     end
-    accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :checking, :scope_identifier => user_scope)
+    accounts.define(identifier: :savings,  scope_identifier: user_scope, positive_only: true)
+    accounts.define(identifier: :checking, scope_identifier: user_scope)
   end
 
   config.define_transfers do |transfers|
-    transfers.define(:from => :checking, :to => :savings,  :code => :deposit)
-    transfers.define(:from => :savings,  :to => :checking, :code => :withdraw)
+    transfers.define(from: :checking, to: :savings,  code: :deposit)
+    transfers.define(from: :savings,  to: :checking, code: :withdraw)
   end
 end
 ```
@@ -225,7 +225,7 @@ Transfers between accounts of different currencies are not allowed.
 ```ruby
 DoubleEntry.configure do |config|
   config.define_accounts do |accounts|
-    accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :currency => 'AUD')
+    accounts.define(identifier: :savings,  scope_identifier: user_scope, currency: 'AUD')
   end
 end
 ```

--- a/lib/active_record/locking_extensions.rb
+++ b/lib/active_record/locking_extensions.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       yield
     rescue ActiveRecord::StatementInvalid => exception
       if exception.message =~ /deadlock/i || exception.message =~ /database is locked/i
-        ActiveSupport::Notifications.publish('deadlock_restart.double_entry', :exception => exception)
+        ActiveSupport::Notifications.publish('deadlock_restart.double_entry', exception: exception)
 
         raise ActiveRecord::RestartTransaction
       else
@@ -46,7 +46,7 @@ module ActiveRecord
       yield
     rescue ActiveRecord::StatementInvalid, ActiveRecord::RecordNotUnique => exception
       if  exception.message =~ /duplicate/i || exception.message =~ /ConstraintException/
-        ActiveSupport::Notifications.publish('duplicate_ignore.double_entry', :exception => exception)
+        ActiveSupport::Notifications.publish('duplicate_ignore.double_entry', exception: exception)
 
         # Just ignore it...someone else has already created the record.
       else
@@ -63,7 +63,7 @@ module ActiveRecord
       if exception.message =~ /deadlock/i || exception.message =~ /database is locked/i
         # Somebody else is in the midst of creating the record. We'd better
         # retry, so we ensure they're done before we move on.
-        ActiveSupport::Notifications.publish('deadlock_retry.double_entry', :exception => exception)
+        ActiveSupport::Notifications.publish('deadlock_retry.double_entry', exception: exception)
 
         retry
       else

--- a/lib/double_entry.rb
+++ b/lib/double_entry.rb
@@ -66,9 +66,9 @@ module DoubleEntry
     #   savings_account  = DoubleEntry.account(:savings,  scope: user)
     #   DoubleEntry.transfer(
     #     20.dollars,
-    #     :from => checking_account,
-    #     :to   => savings_account,
-    #     :code => :save,
+    #     from: checking_account,
+    #     to:   savings_account,
+    #     code: :save,
     #   )
     # @param [Money] amount The quantity of money to transfer from one account
     #   to the other.
@@ -91,35 +91,35 @@ module DoubleEntry
     # Get the current or historic balance of an account.
     #
     # @example Obtain the current balance of my checking account
-    #   checking_account = DoubleEntry.account(:checking, :scope => user)
+    #   checking_account = DoubleEntry.account(:checking, scope: user)
     #   DoubleEntry.balance(checking_account)
     # @example Obtain the current balance of my checking account (without account or user model)
-    #   DoubleEntry.balance(:checking, :scope => user_id)
+    #   DoubleEntry.balance(:checking, scope: user_id)
     # @example Obtain a historic balance of my checking account
-    #   checking_account = DoubleEntry.account(:checking, :scope => user)
-    #   DoubleEntry.balance(checking_account, :at => Time.new(2012, 1, 1))
+    #   checking_account = DoubleEntry.account(:checking, scope: user)
+    #   DoubleEntry.balance(checking_account, at: Time.new(2012, 1, 1))
     # @example Obtain the net balance of my checking account during may
-    #   checking_account = DoubleEntry.account(:checking, :scope => user)
+    #   checking_account = DoubleEntry.account(:checking, scope: user)
     #   DoubleEntry.balance(
     #     checking_account,
-    #     :from => Time.new(2012, 5,  1,  0,  0,  0),
-    #     :to   => Time.new(2012, 5, 31, 23, 59, 59),
+    #     from: Time.new(2012, 5,  1,  0,  0,  0),
+    #     to:   Time.new(2012, 5, 31, 23, 59, 59),
     #   )
     # @example Obtain the balance of salary deposits made to my checking account during may
-    #   checking_account = DoubleEntry.account(:checking, :scope => user)
+    #   checking_account = DoubleEntry.account(:checking, scope: user)
     #   DoubleEntry.balance(
     #     checking_account,
-    #     :code => :salary,
-    #     :from => Time.new(2012, 5,  1,  0,  0,  0),
-    #     :to   => Time.new(2012, 5, 31, 23, 59, 59),
+    #     code: :salary,
+    #     from: Time.new(2012, 5,  1,  0,  0,  0),
+    #     to:   Time.new(2012, 5, 31, 23, 59, 59),
     #   )
     # @example Obtain the balance of salary & lottery deposits made to my checking account during may
-    #   checking_account = DoubleEntry.account(:checking, :scope => user)
+    #   checking_account = DoubleEntry.account(:checking, scope: user)
     #   DoubleEntry.balance(
     #     checking_account,
-    #     :codes => [ :salary, :lottery ],
-    #     :from  => Time.new(2012, 5,  1,  0,  0,  0),
-    #     :to    => Time.new(2012, 5, 31, 23, 59, 59),
+    #     codes: [ :salary, :lottery ],
+    #     from:  Time.new(2012, 5,  1,  0,  0,  0),
+    #     to:    Time.new(2012, 5, 31, 23, 59, 59),
     #   )
     # @param [DoubleEntry::Account:Instance, Symbol] account Find the balance
     #   for this account

--- a/lib/double_entry/account.rb
+++ b/lib/double_entry/account.rb
@@ -15,7 +15,7 @@ module DoubleEntry
       # @api private
       def account(identifier, options = {})
         account = accounts.find(identifier, (options[:scope].present? || options[:scope_identity].present?))
-        Instance.new(:account => account, :scope => options[:scope], :scope_identity => options[:scope_identity])
+        Instance.new(account: account, scope: options[:scope], scope_identity: options[:scope_identity])
       end
 
       # @api private
@@ -67,7 +67,7 @@ module DoubleEntry
 
     class Instance
       attr_reader :account, :scope
-      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :negative_only, :currency, :to => :account
+      delegate :identifier, :scope_identifier, :scoped?, :positive_only, :negative_only, :currency, to: :account
 
       def initialize(args)
         @account = args[:account]

--- a/lib/double_entry/account_balance.rb
+++ b/lib/double_entry/account_balance.rb
@@ -8,7 +8,7 @@ module DoubleEntry
   #
   # Account balances are created on demand when transfers occur.
   class AccountBalance < ActiveRecord::Base
-    delegate :currency, :to => :account
+    delegate :currency, to: :account
 
     def balance
       self[:balance] && Money.new(self[:balance], currency)
@@ -25,11 +25,11 @@ module DoubleEntry
     end
 
     def account
-      DoubleEntry.account(self[:account].to_sym, :scope_identity => self[:scope])
+      DoubleEntry.account(self[:account].to_sym, scope_identity: self[:scope])
     end
 
     def self.find_by_account(account, options = {})
-      scope = where(:scope => account.scope_identity, :account => account.identifier.to_s)
+      scope = where(scope: account.scope_identity, account: account.identifier.to_s)
       scope = scope.lock(true) if options[:lock]
       scope.first
     end

--- a/lib/double_entry/balance_calculator.rb
+++ b/lib/double_entry/balance_calculator.rb
@@ -79,18 +79,18 @@ module DoubleEntry
     # @api private
     class RelationBuilder
       attr_reader :options
-      delegate :account, :scope, :scope?, :from, :to, :between?, :at, :at?, :codes, :code?, :to => :options
+      delegate :account, :scope, :scope?, :from, :to, :between?, :at, :at?, :codes, :code?, to: :options
 
       def initialize(options)
         @options = options
       end
 
       def build
-        lines = Line.where(:account => account)
+        lines = Line.where(account: account)
         lines = lines.where('created_at <= ?', at) if at?
-        lines = lines.where(:created_at => from..to) if between?
-        lines = lines.where(:code => codes) if code?
-        lines = lines.where(:scope => scope) if scope?
+        lines = lines.where(created_at: from..to) if between?
+        lines = lines.where(code: codes) if code?
+        lines = lines.where(scope: scope) if scope?
         lines
       end
     end

--- a/lib/double_entry/configuration.rb
+++ b/lib/double_entry/configuration.rb
@@ -16,7 +16,7 @@ module DoubleEntry
       :scope_identifier_max_length=,
       :account_identifier_max_length,
       :account_identifier_max_length=,
-      :to => 'DoubleEntry::Account',
+      to: 'DoubleEntry::Account',
     )
 
     delegate(
@@ -24,7 +24,7 @@ module DoubleEntry
       :transfers=,
       :code_max_length,
       :code_max_length=,
-      :to => 'DoubleEntry::Transfer',
+      to: 'DoubleEntry::Transfer',
     )
 
     def define_accounts

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -55,8 +55,8 @@ module DoubleEntry
   # by account, or account and code, over a particular period.
   #
   class Line < ActiveRecord::Base
-    belongs_to :detail, :polymorphic => true
-    has_many :metadata, :class_name => 'DoubleEntry::LineMetadata' unless -> { DoubleEntry.config.json_metadata }
+    belongs_to :detail, polymorphic: true
+    has_many :metadata, class_name: 'DoubleEntry::LineMetadata' unless -> { DoubleEntry.config.json_metadata }
     scope :with_id_greater_than, ->(id) { where('id > ?', id) }
 
     def amount
@@ -102,7 +102,7 @@ module DoubleEntry
     end
 
     def account
-      DoubleEntry.account(self[:account].to_sym, :scope_identity => scope)
+      DoubleEntry.account(self[:account].to_sym, scope_identity: scope)
     end
 
     def currency
@@ -117,7 +117,7 @@ module DoubleEntry
     end
 
     def partner_account
-      DoubleEntry.account(self[:partner_account].to_sym, :scope_identity => partner_scope)
+      DoubleEntry.account(self[:partner_account].to_sym, scope_identity: partner_scope)
     end
 
     def partner

--- a/lib/double_entry/locking.rb
+++ b/lib/double_entry/locking.rb
@@ -149,7 +149,7 @@ module DoubleEntry
       # If one or more account balance records don't exist, set
       # accounts_with_balances to the corresponding accounts, and return false.
       def grab_locks
-        account_balances = @accounts.map { |account| AccountBalance.find_by_account(account, :lock => true) }
+        account_balances = @accounts.map { |account| AccountBalance.find_by_account(account, lock: true) }
 
         if account_balances.any?(&:nil?)
           @accounts_without_balances =  @accounts.zip(account_balances).
@@ -168,7 +168,7 @@ module DoubleEntry
           # Get the initial balance from the lines table.
           balance = account.balance
           # Try to create the balance record, but ignore it if someone else has done it in the meantime.
-          AccountBalance.create_ignoring_duplicates!(:account => account, :balance => balance)
+          AccountBalance.create_ignoring_duplicates!(account: account, balance: balance)
         end
       end
     end

--- a/lib/double_entry/transfer.rb
+++ b/lib/double_entry/transfer.rb
@@ -121,8 +121,8 @@ module DoubleEntry
     def create_line_metadata(credit, debit, metadata)
       metadata.each_pair do |key, value|
         Array(value).each do |each_value|
-          LineMetadata.create!(:line => credit, :key => key, :value => each_value)
-          LineMetadata.create!(:line => debit, :key => key, :value => each_value)
+          LineMetadata.create!(line: credit, key: key, value: each_value)
+          LineMetadata.create!(line: debit, key: key, value: each_value)
         end
       end
     end

--- a/lib/double_entry/validation/line_check.rb
+++ b/lib/double_entry/validation/line_check.rb
@@ -34,9 +34,9 @@ module DoubleEntry
 
         unless active_accounts.empty?
           LineCheck.create!(
-            :errors_found => incorrect_accounts.any?,
-            :last_line_id => current_line_id,
-            :log          => log,
+            errors_found: incorrect_accounts.any?,
+            last_line_id: current_line_id,
+            log:          log,
           )
         end
       end

--- a/lib/generators/double_entry/install/templates/initializer.rb
+++ b/lib/generators/double_entry/install/templates/initializer.rb
@@ -9,12 +9,12 @@ DoubleEntry.configure do |config|
   #     raise 'not a User' unless user.class.name == 'User'
   #     user.id
   #   end
-  #   accounts.define(:identifier => :savings,  :scope_identifier => user_scope, :positive_only => true)
-  #   accounts.define(:identifier => :checking, :scope_identifier => user_scope)
+  #   accounts.define(identifier: :savings,  scope_identifier: user_scope, positive_only: true)
+  #   accounts.define(identifier: :checking, scope_identifier: user_scope)
   # end
   #
   # config.define_transfers do |transfers|
-  #   transfers.define(:from => :checking, :to => :savings,  :code => :deposit)
-  #   transfers.define(:from => :savings,  :to => :checking, :code => :withdraw)
+  #   transfers.define(from: :checking, to: :savings,  code: :deposit)
+  #   transfers.define(from: :savings,  to: :checking, code: :withdraw)
   # end
 end

--- a/lib/generators/double_entry/install/templates/migration.rb
+++ b/lib/generators/double_entry/install/templates/migration.rb
@@ -1,25 +1,25 @@
 class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
   def self.up
     create_table "double_entry_account_balances" do |t|
-      t.string     "account", :null => false
+      t.string     "account", null: false
       t.string     "scope"
-      t.bigint     "balance", :null => false
-      t.timestamps            :null => false
+      t.bigint     "balance", null: false
+      t.timestamps            null: false
     end
 
-    add_index "double_entry_account_balances", ["account"],          :name => "index_account_balances_on_account"
-    add_index "double_entry_account_balances", ["scope", "account"], :name => "index_account_balances_on_scope_and_account", :unique => true
+    add_index "double_entry_account_balances", ["account"],          name: "index_account_balances_on_account"
+    add_index "double_entry_account_balances", ["scope", "account"], name: "index_account_balances_on_scope_and_account", unique: true
 
     create_table "double_entry_lines" do |t|
-      t.string     "account",         :null => false
+      t.string     "account",         null: false
       t.string     "scope"
-      t.string     "code",            :null => false
-      t.bigint     "amount",          :null => false
-      t.bigint     "balance",         :null => false
-      t.references "partner",                         :index => false
-      t.string     "partner_account", :null => false
+      t.string     "code",            null: false
+      t.bigint     "amount",          null: false
+      t.bigint     "balance",         null: false
+      t.references "partner",                         index: false
+      t.string     "partner_account", null: false
       t.string     "partner_scope"
-      t.references "detail",                          :index => false, :polymorphic => true
+      t.references "detail",                          index: false, polymorphic: true
       <%- if json_metadata -%>
       if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
         t.jsonb "metadata"
@@ -27,32 +27,32 @@ class CreateDoubleEntryTables < ActiveRecord::Migration<%= migration_version %>
         t.json "metadata"
       end
       <%- end -%>
-      t.timestamps                    :null => false
+      t.timestamps                    null: false
     end
 
-    add_index "double_entry_lines", ["account", "code", "created_at"],  :name => "lines_account_code_created_at_idx"
-    add_index "double_entry_lines", ["account", "created_at"],          :name => "lines_account_created_at_idx"
-    add_index "double_entry_lines", ["scope", "account", "created_at"], :name => "lines_scope_account_created_at_idx"
-    add_index "double_entry_lines", ["scope", "account", "id"],         :name => "lines_scope_account_id_idx"
+    add_index "double_entry_lines", ["account", "code", "created_at"],  name: "lines_account_code_created_at_idx"
+    add_index "double_entry_lines", ["account", "created_at"],          name: "lines_account_created_at_idx"
+    add_index "double_entry_lines", ["scope", "account", "created_at"], name: "lines_scope_account_created_at_idx"
+    add_index "double_entry_lines", ["scope", "account", "id"],         name: "lines_scope_account_id_idx"
 
     create_table "double_entry_line_checks" do |t|
-      t.references "last_line",    :null => false, :index => false
-      t.boolean    "errors_found", :null => false
+      t.references "last_line",    null: false, index: false
+      t.boolean    "errors_found", null: false
       t.text       "log"
-      t.timestamps                 :null => false
+      t.timestamps                 null: false
     end
 
-    add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
+    add_index "double_entry_line_checks", ["created_at", "last_line_id"], name: "line_checks_created_at_last_line_id_idx"
     <%- unless json_metadata -%>
 
     create_table "double_entry_line_metadata" do |t|
-      t.references "line",    :null => false, :index => false
-      t.string     "key",     :null => false
-      t.string     "value",   :null => false
-      t.timestamps            :null => false
+      t.references "line",    null: false, index: false
+      t.string     "key",     null: false
+      t.string     "value",   null: false
+      t.timestamps            null: false
     end
 
-    add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
+    add_index "double_entry_line_metadata", ["line_id", "key", "value"], name: "lines_meta_line_id_key_value_idx"
     <%- end -%>
   end
 

--- a/script/jack_hammer
+++ b/script/jack_hammer
@@ -81,7 +81,7 @@ def create_accounts_and_transfers
     config.define_accounts do |accounts|
       scope = ->(x) { x }
       $account_count.times do |i|
-        accounts.define(:identifier => :"account-#{i}", :scope_identifier => scope)
+        accounts.define(identifier: :"account-#{i}", scope_identifier: scope)
       end
     end
 
@@ -89,14 +89,14 @@ def create_accounts_and_transfers
     config.define_transfers do |transfers|
       config.accounts.each do |from|
         config.accounts.each do |to|
-          transfers.define(:from => from.identifier, :to => to.identifier, :code => :test)
+          transfers.define(from: from.identifier, to: to.identifier, code: :test)
         end
       end
     end
 
     # Find account instances so we have something to work with.
     $accounts = config.accounts.map do |account|
-      DoubleEntry.account(account.identifier, :scope => 1)
+      DoubleEntry.account(account.identifier, scope: 1)
     end
   end
 end
@@ -143,15 +143,15 @@ def run_process(iterations, process_num)
     account_b = ($accounts - [account_a]).sample
     amount = rand(1000) + 1
 
-    DoubleEntry.transfer(Money.new(amount), :from => account_a, :to => account_b, :code => :test)
+    DoubleEntry.transfer(Money.new(amount), from: account_a, to: account_b, code: :test)
 
     puts "Process #{process_num} completed #{i+1} transfers" if (i+1) % 100 == 0
   end
 end
 
 def reconciled?(account)
-  scoped_lines = DoubleEntry::Line.where(:account => "#{account.identifier}")
-  scoped_lines = scoped_lines.where(:scope => "#{account.scope_identity}") if account.scoped?
+  scoped_lines = DoubleEntry::Line.where(account: "#{account.identifier}")
+  scoped_lines = scoped_lines.where(scope: "#{account.scope_identity}") if account.scoped?
   sum_of_amounts = scoped_lines.sum(:amount)
   final_balance  = scoped_lines.order(:id).last[:balance]
   cached_balance = DoubleEntry::AccountBalance.find_by_account(account)[:balance]

--- a/spec/active_record/locking_extensions_spec.rb
+++ b/spec/active_record/locking_extensions_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
       it 'publishes a notification' do
         expect(ActiveSupport::Notifications).
           to receive(:publish).
-          with('deadlock_restart.double_entry', hash_including(:exception => exception))
+          with('deadlock_restart.double_entry', hash_including(exception: exception))
         expect { User.with_restart_on_deadlock { fail exception } }.to raise_error(ActiveRecord::RestartTransaction)
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
       create(:user, username: 'keith')
 
       expect { create(:user, username: 'keith') }.to raise_error(ActiveRecord::RecordNotUnique)
-      expect { User.create_ignoring_duplicates! :username => 'keith' }.to_not raise_error
+      expect { User.create_ignoring_duplicates! username: 'keith' }.to_not raise_error
     end
 
     it 'publishes a notification when a duplicate is encountered' do
@@ -62,9 +62,9 @@ RSpec.describe ActiveRecord::LockingExtensions do
 
       expect(ActiveSupport::Notifications).
         to receive(:publish).
-        with('duplicate_ignore.double_entry', hash_including(:exception => kind_of(ActiveRecord::RecordNotUnique)))
+        with('duplicate_ignore.double_entry', hash_including(exception: kind_of(ActiveRecord::RecordNotUnique)))
 
-      expect { User.create_ignoring_duplicates! :username => 'keith' }.to_not raise_error
+      expect { User.create_ignoring_duplicates! username: 'keith' }.to_not raise_error
     end
 
     shared_examples 'abstract adapter' do
@@ -82,7 +82,7 @@ RSpec.describe ActiveRecord::LockingExtensions do
 
         expect(ActiveSupport::Notifications).
           to receive(:publish).
-          with('deadlock_retry.double_entry', hash_including(:exception => exception)).
+          with('deadlock_retry.double_entry', hash_including(exception: exception)).
           twice
 
         expect { User.create_ignoring_duplicates! }.to_not raise_error

--- a/spec/double_entry/account_balance_spec.rb
+++ b/spec/double_entry/account_balance_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DoubleEntry::AccountBalance do
     subject(:scopes) { DoubleEntry::AccountBalance.scopes_with_minimum_balance_for_account(minimum_balance, :checking) }
 
     context "a 'checking' account with balance $100" do
-      let!(:user) { create(:user, :checking_balance => Money.new(100_00)) }
+      let!(:user) { create(:user, checking_balance: Money.new(100_00)) }
 
       context 'when searching for balance $99' do
         let(:minimum_balance) { Money.new(99_00) }

--- a/spec/double_entry/account_spec.rb
+++ b/spec/double_entry/account_spec.rb
@@ -11,14 +11,14 @@ module DoubleEntry
         context 'given an identifier 31 characters in length' do
           let(:identifier) { 'xxxxxxxx 31 characters xxxxxxxx' }
           specify do
-            expect { Account.new(:identifier => identifier) }.to_not raise_error
+            expect { Account.new(identifier: identifier) }.to_not raise_error
           end
         end
 
         context 'given an identifier 32 characters in length' do
           let(:identifier) { 'xxxxxxxx 32 characters xxxxxxxxx' }
           specify do
-            expect { Account.new(:identifier => identifier) }.to raise_error AccountIdentifierTooLongError, /'#{identifier}'/
+            expect { Account.new(identifier: identifier) }.to raise_error AccountIdentifierTooLongError, /'#{identifier}'/
           end
         end
       end
@@ -26,25 +26,25 @@ module DoubleEntry
 
     describe Account::Instance do
       it 'is sortable' do
-        account = Account.new(:identifier => 'savings', :scope_identifier => identity_scope)
-        a = Account::Instance.new(:account => account, :scope => '123')
-        b = Account::Instance.new(:account => account, :scope => '456')
+        account = Account.new(identifier: 'savings', scope_identifier: identity_scope)
+        a = Account::Instance.new(account: account, scope: '123')
+        b = Account::Instance.new(account: account, scope: '456')
         expect([b, a].sort).to eq [a, b]
       end
 
       it 'is hashable' do
-        account = Account.new(:identifier => 'savings', :scope_identifier => identity_scope)
-        a1 = Account::Instance.new(:account => account, :scope => '123')
-        a2 = Account::Instance.new(:account => account, :scope => '123')
-        b  = Account::Instance.new(:account => account, :scope => '456')
+        account = Account.new(identifier: 'savings', scope_identifier: identity_scope)
+        a1 = Account::Instance.new(account: account, scope: '123')
+        a2 = Account::Instance.new(account: account, scope: '123')
+        b  = Account::Instance.new(account: account, scope: '456')
 
         expect(a1.hash).to eq a2.hash
         expect(a1.hash).to_not eq b.hash
       end
 
       describe '::new' do
-        let(:account) { Account.new(:identifier => 'x', :scope_identifier => identity_scope) }
-        subject(:initialize_account_instance) { Account::Instance.new(:account => account, :scope => scope) }
+        let(:account) { Account.new(identifier: 'x', scope_identifier: identity_scope) }
+        subject(:initialize_account_instance) { Account::Instance.new(account: account, scope: scope) }
 
         context 'given a scope_identifier_max_length of 23' do
           before { Account.scope_identifier_max_length = 23 }
@@ -65,13 +65,13 @@ module DoubleEntry
 
     describe 'currency' do
       it 'defaults to USD currency' do
-        account = DoubleEntry::Account.new(:identifier => 'savings', :scope_identifier => identity_scope)
-        expect(DoubleEntry::Account::Instance.new(:account => account).currency).to eq('USD')
+        account = DoubleEntry::Account.new(identifier: 'savings', scope_identifier: identity_scope)
+        expect(DoubleEntry::Account::Instance.new(account: account).currency).to eq('USD')
       end
 
       it 'allows the currency to be set' do
-        account = DoubleEntry::Account.new(:identifier => 'savings', :scope_identifier => identity_scope, :currency => 'AUD')
-        expect(DoubleEntry::Account::Instance.new(:account => account).currency).to eq('AUD')
+        account = DoubleEntry::Account.new(identifier: 'savings', scope_identifier: identity_scope, currency: 'AUD')
+        expect(DoubleEntry::Account::Instance.new(account: account).currency).to eq('AUD')
       end
     end
 
@@ -80,8 +80,8 @@ module DoubleEntry
 
       describe '#find' do
         before do
-          set.define(:identifier => :savings)
-          set.define(:identifier => :checking, :scope_identifier => ar_class)
+          set.define(identifier: :savings)
+          set.define(identifier: :checking, scope_identifier: ar_class)
         end
 
         let(:ar_class) { double(:ar_class) }

--- a/spec/double_entry/balance_calculator_spec.rb
+++ b/spec/double_entry/balance_calculator_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe DoubleEntry::BalanceCalculator do
   describe '#calculate' do
-    let(:account) { DoubleEntry.account(:test, :scope => scope) }
+    let(:account) { DoubleEntry.account(:test, scope: scope) }
     let(:scope) { create(:user) }
     let(:from) { nil }
     let(:to) { nil }
@@ -15,12 +15,12 @@ RSpec.describe DoubleEntry::BalanceCalculator do
       allow(DoubleEntry::Line).to receive(:where).and_return(relation)
       DoubleEntry::BalanceCalculator.calculate(
         account,
-        :scope => scope,
-        :from => from,
-        :to => to,
-        :at => at,
-        :code => code,
-        :codes => codes,
+        scope: scope,
+        from: from,
+        to: to,
+        at: at,
+        code: code,
+        codes: codes,
       )
     end
 
@@ -40,7 +40,7 @@ RSpec.describe DoubleEntry::BalanceCalculator do
 
           it 'ignores the time range when summing the lines' do
             expect(relation).to_not have_received(:where).with(
-              :created_at => Time.parse('2014-06-19 10:09:18 +1000')..Time.parse('2014-06-19 20:09:18 +1000'),
+              created_at: Time.parse('2014-06-19 10:09:18 +1000')..Time.parse('2014-06-19 20:09:18 +1000'),
             )
             expect(relation).to_not have_received(:sum)
           end
@@ -53,7 +53,7 @@ RSpec.describe DoubleEntry::BalanceCalculator do
 
         it 'scopes the lines summed to times within the given range' do
           expect(relation).to have_received(:where).with(
-            :created_at => Time.parse('2014-06-19 10:09:18 +1000')..Time.parse('2014-06-19 20:09:18 +1000'),
+            created_at: Time.parse('2014-06-19 10:09:18 +1000')..Time.parse('2014-06-19 20:09:18 +1000'),
           )
           expect(relation).to have_received(:sum).with(:amount)
         end
@@ -64,7 +64,7 @@ RSpec.describe DoubleEntry::BalanceCalculator do
       let(:code) { 'code1' }
 
       it 'scopes the lines summed by the given code' do
-        expect(relation).to have_received(:where).with(:code => ['code1'])
+        expect(relation).to have_received(:where).with(code: ['code1'])
         expect(relation).to have_received(:sum).with(:amount)
       end
     end
@@ -73,14 +73,14 @@ RSpec.describe DoubleEntry::BalanceCalculator do
       let(:codes) { %w(code1 code2) }
 
       it 'scopes the lines summed by the given codes' do
-        expect(relation).to have_received(:where).with(:code => %w(code1 code2))
+        expect(relation).to have_received(:where).with(code: %w(code1 code2))
         expect(relation).to have_received(:sum).with(:amount)
       end
     end
 
     context 'when no codes are provided' do
       it 'does not scope the lines summed by any code' do
-        expect(relation).to_not have_received(:where).with(:code => anything)
+        expect(relation).to_not have_received(:where).with(code: anything)
         expect(relation).to_not have_received(:sum).with(:amount)
       end
     end

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe DoubleEntry::Line do
   describe 'persistance' do
     let(:line_to_persist) do
       DoubleEntry::Line.new(
-        :amount => Money.new(10_00),
-        :balance => Money.zero,
-        :account => account,
-        :partner_account => partner_account,
-        :code => code,
+        amount: Money.new(10_00),
+        balance: Money.zero,
+        account: account,
+        partner_account: partner_account,
+        code: code,
       )
     end
-    let(:account) { DoubleEntry.account(:test, :scope_identity => '17') }
-    let(:partner_account) { DoubleEntry.account(:test, :scope_identity => '72') }
+    let(:account) { DoubleEntry.account(:test, scope_identity: '17') }
+    let(:partner_account) { DoubleEntry.account(:test, scope_identity: '72') }
     let(:code) { :test_code }
 
     subject(:persisted_line) do
@@ -42,28 +42,28 @@ RSpec.describe DoubleEntry::Line do
       end
 
       context 'given account = :test, 54 ' do
-        let(:account) { DoubleEntry.account(:test, :scope_identity => '54') }
+        let(:account) { DoubleEntry.account(:test, scope_identity: '54') }
         its('account.account.identifier') { should eq :test }
         its('account.scope_identity') { should eq '54' }
       end
 
       context 'given partner_account = :test, 91 ' do
-        let(:partner_account) { DoubleEntry.account(:test, :scope_identity => '91') }
+        let(:partner_account) { DoubleEntry.account(:test, scope_identity: '91') }
         its('partner_account.account.identifier') { should eq :test }
         its('partner_account.scope_identity') { should eq '91' }
       end
 
       context 'currency' do
-        let(:account) { DoubleEntry.account(:btc_test, :scope_identity => '17') }
-        let(:partner_account) { DoubleEntry.account(:btc_test, :scope_identity => '72') }
+        let(:account) { DoubleEntry.account(:btc_test, scope_identity: '17') }
+        let(:partner_account) { DoubleEntry.account(:btc_test, scope_identity: '72') }
         its(:currency) { should eq 'BTC' }
       end
     end
 
     context 'when balance is sent negative' do
-      before { DoubleEntry::Account.accounts.define(:identifier => :a_positive_only_acc, :positive_only => true) }
+      before { DoubleEntry::Account.accounts.define(identifier: :a_positive_only_acc, positive_only: true) }
       let(:account) { DoubleEntry.account(:a_positive_only_acc) }
-      let(:line) { DoubleEntry::Line.new(:balance => Money.new(-1), :account => account) }
+      let(:line) { DoubleEntry::Line.new(balance: Money.new(-1), account: account) }
 
       it 'raises AccountWouldBeSentNegative error' do
         expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentNegative
@@ -71,9 +71,9 @@ RSpec.describe DoubleEntry::Line do
     end
 
     context 'when balance is sent positive' do
-      before { DoubleEntry::Account.accounts.define(:identifier => :a_negative_only_acc, :negative_only => true) }
+      before { DoubleEntry::Account.accounts.define(identifier: :a_negative_only_acc, negative_only: true) }
       let(:account) { DoubleEntry.account(:a_negative_only_acc) }
-      let(:line) { DoubleEntry::Line.new(:balance => Money.new(1), :account => account) }
+      let(:line) { DoubleEntry::Line.new(balance: Money.new(1), account: account) }
 
       it 'raises AccountWouldBeSentPositiveError' do
         expect { line.save }.to raise_error DoubleEntry::AccountWouldBeSentPositiveError

--- a/spec/double_entry/transfer_spec.rb
+++ b/spec/double_entry/transfer_spec.rb
@@ -9,14 +9,14 @@ module DoubleEntry
         context 'given a code 47 characters in length' do
           let(:code) { 'xxxxxxxxxxxxxxxx 47 characters xxxxxxxxxxxxxxxx' }
           specify do
-            expect { Transfer.new(:code => code) }.to_not raise_error
+            expect { Transfer.new(code: code) }.to_not raise_error
           end
         end
 
         context 'given a code 48 characters in length' do
           let(:code) { 'xxxxxxxxxxxxxxxx 48 characters xxxxxxxxxxxxxxxxx' }
           specify do
-            expect { Transfer.new(:code => code) }.to raise_error TransferCodeTooLongError, /'#{code}'/
+            expect { Transfer.new(code: code) }.to raise_error TransferCodeTooLongError, /'#{code}'/
           end
         end
       end
@@ -25,14 +25,14 @@ module DoubleEntry
     describe '::transfer' do
       let(:amount)  { Money.new(10_00) }
       let(:user)    { create(:user) }
-      let(:test)    { DoubleEntry.account(:test, :scope => user) }
-      let(:savings) { DoubleEntry.account(:savings, :scope => user) }
+      let(:test)    { DoubleEntry.account(:test, scope: user) }
+      let(:savings) { DoubleEntry.account(:savings, scope: user) }
       let(:new_lines) { Line.all[-2..-1] }
 
       subject(:transfer) { Transfer.transfer(amount, options) }
 
       context 'without metadata' do
-        let(:options) { { :from => test, :to => savings, :code => :bonus } }
+        let(:options) { { from: test, to: savings, code: :bonus } }
 
         it 'creates lines' do
           expect { transfer }.to change { Line.count }.by 2
@@ -72,7 +72,7 @@ module DoubleEntry
       end
 
       context 'with metadata' do
-        let(:options) { { :from => test, :to => savings, :code => :bonus, :metadata => { :country => 'AU', :tax => 'GST' } } }
+        let(:options) { { from: test, to: savings, code: :bonus, metadata: { country: 'AU', tax: 'GST' } } }
 
         context 'with config.json_metadata = true', skip: ActiveRecord.version.version < '5' do
           around do |example|
@@ -140,7 +140,7 @@ module DoubleEntry
       end
 
       context 'metadata with multiple values in array for one key' do
-        let(:options) { { :from => test, :to => savings, :code => :bonus, :metadata => { :tax => ['GST', 'VAT'] } } }
+        let(:options) { { from: test, to: savings, code: :bonus, metadata: { tax: ['GST', 'VAT'] } } }
 
         context 'with config.json_metadata = true', skip: ActiveRecord.version.version < '5' do
           around do |example|
@@ -195,20 +195,20 @@ module DoubleEntry
 
       before do
         set.define(
-          :code => :transfer_code,
-          :from => from_account.identifier,
-          :to   => to_account.identifier,
+          code: :transfer_code,
+          from: from_account.identifier,
+          to:    to_account.identifier,
         )
 
         set.define(
-          :code => :another_transfer_code,
-          :from => from_account.identifier,
-          :to   => to_account.identifier,
+          code: :another_transfer_code,
+          from: from_account.identifier,
+          to:    to_account.identifier,
         )
       end
 
-      let(:from_account) { instance_double(Account, :identifier => :from) }
-      let(:to_account)   { instance_double(Account, :identifier => :to) }
+      let(:from_account) { instance_double(Account, identifier: :from) }
+      let(:to_account)   { instance_double(Account, identifier: :to) }
 
       describe '#find' do
         it 'finds the transfers' do

--- a/spec/double_entry/validation/line_check_spec.rb
+++ b/spec/double_entry/validation/line_check_spec.rb
@@ -8,13 +8,13 @@ module DoubleEntry
         context 'Given some checks have been created' do
           before do
             Timecop.freeze 3.minutes.ago do
-              LineCheck.create! :last_line_id => 100, :errors_found => false, :log => ''
+              LineCheck.create! last_line_id: 100, errors_found: false, log: ''
             end
             Timecop.freeze 1.minute.ago do
-              LineCheck.create! :last_line_id => 300, :errors_found => false, :log => ''
+              LineCheck.create! last_line_id: 300, errors_found: false, log: ''
             end
             Timecop.freeze 2.minutes.ago do
-              LineCheck.create! :last_line_id => 200, :errors_found => false, :log => ''
+              LineCheck.create! last_line_id: 200, errors_found: false, log: ''
             end
           end
 
@@ -28,7 +28,7 @@ module DoubleEntry
         subject(:line_check) { LineCheck.perform!(fixer: AccountFixer.new) }
 
         context 'Given a user with 100 dollars' do
-          before { create(:user, :savings_balance => Money.new(100_00)) }
+          before { create(:user, savings_balance: Money.new(100_00)) }
 
           context 'And all is consistent' do
             context 'And all lines have been checked' do
@@ -94,7 +94,7 @@ module DoubleEntry
         end
 
         context 'Given a user with a non default currency balance' do
-          before { create(:user, :bitcoin_balance => Money.new(100_00, 'BTC')) }
+          before { create(:user, bitcoin_balance: Money.new(100_00, 'BTC')) }
           its(:errors_found) { should eq false }
           context 'And there is a consistency error in lines' do
             before { DoubleEntry::Line.order(:id).limit(1).update_all('balance = balance + 1') }

--- a/spec/double_entry_spec.rb
+++ b/spec/double_entry_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.configure do |config|
           config.define_accounts do |accounts|
-            accounts.define(:identifier => :gah!)
-            accounts.define(:identifier => :gah!)
+            accounts.define(identifier: :gah!)
+            accounts.define(identifier: :gah!)
           end
         end
       end.to raise_error DoubleEntry::DuplicateAccount
@@ -30,8 +30,8 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.configure do |config|
           config.define_transfers do |transfers|
-            transfers.define(:from => :savings, :to => :cash, :code => :xfer)
-            transfers.define(:from => :savings, :to => :cash, :code => :xfer)
+            transfers.define(from: :savings, to: :cash, code: :xfer)
+            transfers.define(from: :savings, to: :cash, code: :xfer)
           end
         end
       end.to raise_error DoubleEntry::DuplicateTransfer
@@ -42,13 +42,13 @@ RSpec.describe DoubleEntry do
     before do
       DoubleEntry.configure do |config|
         config.define_accounts do |accounts|
-          accounts.define(:identifier => :unscoped)
-          accounts.define(:identifier => :scoped, :scope_identifier => ->(u) { u.id })
+          accounts.define(identifier: :unscoped)
+          accounts.define(identifier: :scoped, scope_identifier: ->(u) { u.id })
         end
       end
     end
 
-    let(:scope) { double('a scope', :id => 1) }
+    let(:scope) { double('a scope', id: 1) }
 
     describe 'fetching' do
       it 'can find an unscoped account by identifier' do
@@ -56,7 +56,7 @@ RSpec.describe DoubleEntry do
       end
 
       it 'can find a scoped account by identifier' do
-        expect(DoubleEntry.account(:scoped, :scope => scope)).to_not be_nil
+        expect(DoubleEntry.account(:scoped, scope: scope)).to_not be_nil
       end
 
       it 'raises an exception when it cannot find an account' do
@@ -64,7 +64,7 @@ RSpec.describe DoubleEntry do
       end
 
       it 'raises exception when you ask for an unscoped account w/ scope' do
-        expect { DoubleEntry.account(:unscoped, :scope => scope) }.to raise_error(DoubleEntry::UnknownAccount)
+        expect { DoubleEntry.account(:unscoped, scope: scope) }.to raise_error(DoubleEntry::UnknownAccount)
       end
 
       it 'raises exception when you ask for a scoped account w/ out scope' do
@@ -80,7 +80,7 @@ RSpec.describe DoubleEntry do
       end
     end
     context 'a scoped account' do
-      subject(:scoped) { DoubleEntry.account(:scoped, :scope => scope) }
+      subject(:scoped) { DoubleEntry.account(:scoped, scope: scope) }
 
       it 'has an identifier' do
         expect(scoped.identifier).to eq :scoped
@@ -92,15 +92,15 @@ RSpec.describe DoubleEntry do
     before do
       DoubleEntry.configure do |config|
         config.define_accounts do |accounts|
-          accounts.define(:identifier => :savings)
-          accounts.define(:identifier => :cash)
-          accounts.define(:identifier => :trash)
-          accounts.define(:identifier => :bitbucket, :currency => :btc)
+          accounts.define(identifier: :savings)
+          accounts.define(identifier: :cash)
+          accounts.define(identifier: :trash)
+          accounts.define(identifier: :bitbucket, currency: :btc)
         end
 
         config.define_transfers do |transfers|
-          transfers.define(:from => :savings, :to => :cash, :code => :xfer)
-          transfers.define(:from => :trash, :to => :bitbucket, :code => :mismatch_xfer)
+          transfers.define(from: :savings, to: :cash, code: :xfer)
+          transfers.define(from: :trash, to: :bitbucket, code: :mismatch_xfer)
         end
       end
     end
@@ -113,9 +113,9 @@ RSpec.describe DoubleEntry do
     it 'can transfer from an account to an account, if the transfer is allowed' do
       DoubleEntry.transfer(
         Money.new(100_00),
-        :from => savings,
-        :to   => cash,
-        :code => :xfer,
+        from: savings,
+        to:    cash,
+        code: :xfer,
       )
     end
 
@@ -123,9 +123,9 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.transfer(
           Money.new(100_00),
-          :from => cash,
-          :to   => savings,
-          :code => :xfer,
+          from: cash,
+          to:    savings,
+          code: :xfer,
         )
       end.to raise_error DoubleEntry::TransferNotAllowed
     end
@@ -134,9 +134,9 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.transfer(
           Money.new(100_00),
-          :from => savings,
-          :to   => cash,
-          :code => :yfer,
+          from: savings,
+          to:    cash,
+          code: :yfer,
         )
       end.to raise_error DoubleEntry::TransferNotAllowed
     end
@@ -145,8 +145,8 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.transfer(
           Money.new(100_00),
-          :from => cash,
-          :to   => trash,
+          from: cash,
+          to:    trash,
         )
       end.to raise_error DoubleEntry::TransferNotAllowed
     end
@@ -155,9 +155,9 @@ RSpec.describe DoubleEntry do
       expect do
         DoubleEntry.transfer(
           Money.new(100_00),
-          :from => trash,
-          :to   => bitbucket,
-          :code => :mismatch_xfer,
+          from: trash,
+          to:    bitbucket,
+          code: :mismatch_xfer,
         )
       end.to raise_error DoubleEntry::MismatchedCurrencies
     end
@@ -167,16 +167,16 @@ RSpec.describe DoubleEntry do
     before do
       DoubleEntry.configure do |config|
         config.define_accounts do |accounts|
-          accounts.define(:identifier => :a)
-          accounts.define(:identifier => :b)
+          accounts.define(identifier: :a)
+          accounts.define(identifier: :b)
         end
 
         config.define_transfers do |transfers|
-          transfers.define(:code => :xfer, :from => :a, :to => :b)
+          transfers.define(code: :xfer, from: :a, to: :b)
         end
       end
 
-      DoubleEntry.transfer(Money.new(10_00), :from => account_a, :to => account_b, :code => :xfer)
+      DoubleEntry.transfer(Money.new(10_00), from: account_a, to: account_b, code: :xfer)
     end
 
     let(:account_a) { DoubleEntry.account(:a) }
@@ -239,51 +239,51 @@ RSpec.describe DoubleEntry do
     before do
       DoubleEntry.configure do |config|
         config.define_accounts do |accounts|
-          accounts.define(:identifier => :work)
-          accounts.define(:identifier => :cash)
-          accounts.define(:identifier => :savings)
-          accounts.define(:identifier => :store)
-          accounts.define(:identifier => :btc_store, :currency => 'BTC')
-          accounts.define(:identifier => :btc_wallet, :currency => 'BTC')
+          accounts.define(identifier: :work)
+          accounts.define(identifier: :cash)
+          accounts.define(identifier: :savings)
+          accounts.define(identifier: :store)
+          accounts.define(identifier: :btc_store, currency: 'BTC')
+          accounts.define(identifier: :btc_wallet, currency: 'BTC')
         end
 
         config.define_transfers do |transfers|
-          transfers.define(:code => :salary,   :from => :work,    :to => :cash)
-          transfers.define(:code => :xfer,     :from => :cash,    :to => :savings)
-          transfers.define(:code => :xfer,     :from => :savings, :to => :cash)
-          transfers.define(:code => :purchase, :from => :cash,    :to => :store)
-          transfers.define(:code => :layby,    :from => :cash,    :to => :store)
-          transfers.define(:code => :deposit,  :from => :cash,    :to => :store)
-          transfers.define(:code => :btc_ex,   :from => :btc_store,    :to => :btc_wallet)
+          transfers.define(code: :salary,   from: :work,    to: :cash)
+          transfers.define(code: :xfer,     from: :cash,    to: :savings)
+          transfers.define(code: :xfer,     from: :savings, to: :cash)
+          transfers.define(code: :purchase, from: :cash,    to: :store)
+          transfers.define(code: :layby,    from: :cash,    to: :store)
+          transfers.define(code: :deposit,  from: :cash,    to: :store)
+          transfers.define(code: :btc_ex,   from: :btc_store,    to: :btc_wallet)
         end
       end
 
       Timecop.freeze 3.weeks.ago + 1.day do
         # got paid from work
-        DoubleEntry.transfer(Money.new(1_000_00), :from => work, :code => :salary, :to => cash)
+        DoubleEntry.transfer(Money.new(1_000_00), from: work, code: :salary, to: cash)
         # transfer half salary into savings
-        DoubleEntry.transfer(Money.new(500_00), :from => cash, :code => :xfer, :to => savings)
+        DoubleEntry.transfer(Money.new(500_00), from: cash, code: :xfer, to: savings)
       end
 
       Timecop.freeze 2.weeks.ago + 1.day do
         # got myself a darth vader helmet
-        DoubleEntry.transfer(Money.new(200_00), :from => cash, :code => :purchase, :to => store)
+        DoubleEntry.transfer(Money.new(200_00), from: cash, code: :purchase, to: store)
         # paid off some of my darth vader suit layby (to go with the helmet)
-        DoubleEntry.transfer(Money.new(100_00), :from => cash, :code => :layby, :to => store)
+        DoubleEntry.transfer(Money.new(100_00), from: cash, code: :layby, to: store)
         # put a deposit on the darth vader voice changer module (for the helmet)
-        DoubleEntry.transfer(Money.new(100_00), :from => cash, :code => :deposit, :to => store)
+        DoubleEntry.transfer(Money.new(100_00), from: cash, code: :deposit, to: store)
       end
 
       Timecop.freeze 1.week.ago + 1.day do
         # transfer 200 out of savings
-        DoubleEntry.transfer(Money.new(200_00), :from => savings, :code => :xfer, :to => cash)
+        DoubleEntry.transfer(Money.new(200_00), from: savings, code: :xfer, to: cash)
         # pay the remaining balance on the darth vader voice changer module
-        DoubleEntry.transfer(Money.new(200_00), :from => cash, :code => :purchase, :to => store)
+        DoubleEntry.transfer(Money.new(200_00), from: cash, code: :purchase, to: store)
       end
 
       Timecop.freeze 1.week.from_now do
         # it's the future, man
-        DoubleEntry.transfer(Money.new(200_00, 'BTC'), :from => btc_store, :code => :btc_ex, :to => btc_wallet)
+        DoubleEntry.transfer(Money.new(200_00, 'BTC'), from: btc_store, code: :btc_ex, to: btc_wallet)
       end
     end
 
@@ -310,30 +310,30 @@ RSpec.describe DoubleEntry do
       cash_balance = cash.balance
       amount = Money.new(10_00)
 
-      DoubleEntry.transfer(amount, :from => savings, :code => :xfer, :to => cash)
+      DoubleEntry.transfer(amount, from: savings, code: :xfer, to: cash)
 
       expect(savings.balance).to eq(savings_balance - amount)
       expect(cash.balance).to eq(cash_balance + amount)
     end
 
     it 'can be queried at a given point in time' do
-      expect(cash.balance(:at => 1.week.ago)).to eq(Money.new(100_00))
+      expect(cash.balance(at: 1.week.ago)).to eq(Money.new(100_00))
     end
 
     it 'can be queries between two points in time' do
-      expect(cash.balance(:from => 3.weeks.ago, :to => 2.weeks.ago)).to eq(Money.new(500_00))
+      expect(cash.balance(from: 3.weeks.ago, to: 2.weeks.ago)).to eq(Money.new(500_00))
     end
 
     it 'can be queried between two points in time, even in the future' do
-      expect(btc_wallet.balance(:from => Time.now, :to => 2.weeks.from_now)).to eq(Money.new(200_00, 'BTC'))
+      expect(btc_wallet.balance(from: Time.now, to: 2.weeks.from_now)).to eq(Money.new(200_00, 'BTC'))
     end
 
     it 'can report on balances, scoped by code' do
-      expect(cash.balance(:code => :salary)).to eq Money.new(1_000_00)
+      expect(cash.balance(code: :salary)).to eq Money.new(1_000_00)
     end
 
     it 'can report on balances, scoped by many codes' do
-      expect(store.balance(:codes => [:layby, :deposit])).to eq(Money.new(200_00))
+      expect(store.balance(codes: [:layby, :deposit])).to eq(Money.new(200_00))
     end
 
     it 'has running balances for each line' do
@@ -356,15 +356,15 @@ RSpec.describe DoubleEntry do
             raise 'not a User' unless user.class.name == 'User'
             user.id
           end
-          accounts.define(:identifier => :bank)
-          accounts.define(:identifier => :cash,    :scope_identifier => user_scope)
-          accounts.define(:identifier => :savings, :scope_identifier => user_scope)
+          accounts.define(identifier: :bank)
+          accounts.define(identifier: :cash,    scope_identifier: user_scope)
+          accounts.define(identifier: :savings, scope_identifier: user_scope)
         end
 
         config.define_transfers do |transfers|
-          transfers.define(:from => :bank, :to => :cash,    :code => :xfer)
-          transfers.define(:from => :cash, :to => :cash,    :code => :xfer)
-          transfers.define(:from => :cash, :to => :savings, :code => :xfer)
+          transfers.define(from: :bank, to: :cash,    code: :xfer)
+          transfers.define(from: :cash, to: :cash,    code: :xfer)
+          transfers.define(from: :cash, to: :savings, code: :xfer)
         end
       end
     end
@@ -374,52 +374,52 @@ RSpec.describe DoubleEntry do
     let(:savings) { DoubleEntry.account(:savings) }
 
     let(:john) { create(:user) }
-    let(:johns_cash) { DoubleEntry.account(:cash, :scope => john) }
-    let(:johns_savings) { DoubleEntry.account(:savings, :scope => john) }
+    let(:johns_cash) { DoubleEntry.account(:cash, scope: john) }
+    let(:johns_savings) { DoubleEntry.account(:savings, scope: john) }
 
     let(:ryan) { create(:user) }
-    let(:ryans_cash) { DoubleEntry.account(:cash, :scope => ryan) }
-    let(:ryans_savings) { DoubleEntry.account(:savings, :scope => ryan) }
+    let(:ryans_cash) { DoubleEntry.account(:cash, scope: ryan) }
+    let(:ryans_savings) { DoubleEntry.account(:savings, scope: ryan) }
 
     it 'treats each separately scoped account having their own separate balances' do
-      DoubleEntry.transfer(Money.new(20_00), :from => bank, :to => johns_cash, :code => :xfer)
-      DoubleEntry.transfer(Money.new(10_00), :from => bank, :to => ryans_cash, :code => :xfer)
+      DoubleEntry.transfer(Money.new(20_00), from: bank, to: johns_cash, code: :xfer)
+      DoubleEntry.transfer(Money.new(10_00), from: bank, to: ryans_cash, code: :xfer)
       expect(johns_cash.balance).to eq(Money.new(20_00))
       expect(ryans_cash.balance).to eq(Money.new(10_00))
     end
 
     it 'allows transfer between two separately scoped accounts' do
-      DoubleEntry.transfer(Money.new(10_00), :from => ryans_cash, :to => johns_cash, :code => :xfer)
+      DoubleEntry.transfer(Money.new(10_00), from: ryans_cash, to: johns_cash, code: :xfer)
       expect(ryans_cash.balance).to eq(Money.new(-10_00))
       expect(johns_cash.balance).to eq(Money.new(10_00))
     end
 
     it 'reports balance correctly if called from either account or finances object' do
-      DoubleEntry.transfer(Money.new(10_00), :from => ryans_cash, :to => johns_cash, :code => :xfer)
+      DoubleEntry.transfer(Money.new(10_00), from: ryans_cash, to: johns_cash, code: :xfer)
       expect(ryans_cash.balance).to eq(Money.new(-10_00))
-      expect(DoubleEntry.balance(:cash, :scope => ryan)).to eq(Money.new(-10_00))
+      expect(DoubleEntry.balance(:cash, scope: ryan)).to eq(Money.new(-10_00))
     end
 
     it 'raises an exception if you try to scope with an object instance of differing class to that defined on the account' do
-      not_a_user = double(:id => 7)
+      not_a_user = double(id: 7)
 
       expect do
-        DoubleEntry.account(:savings, :scope => not_a_user)
+        DoubleEntry.account(:savings, scope: not_a_user)
       end.to raise_error RuntimeError, 'not a User'
 
       expect do
-        DoubleEntry.balance(:savings, :scope => not_a_user)
+        DoubleEntry.balance(:savings, scope: not_a_user)
       end.to raise_error RuntimeError, 'not a User'
     end
 
     it 'raises exception if you try to transfer between the same account, despite it being scoped' do
       expect do
-        DoubleEntry.transfer(Money.new(10_00), :from => ryans_cash, :to => ryans_cash, :code => :xfer)
+        DoubleEntry.transfer(Money.new(10_00), from: ryans_cash, to: ryans_cash, code: :xfer)
       end.to raise_error(DoubleEntry::TransferNotAllowed)
     end
 
     it 'allows transfer from one persons account to the same persons other kind of account' do
-      DoubleEntry.transfer(Money.new(100_00), :from => ryans_cash, :to => ryans_savings, :code => :xfer)
+      DoubleEntry.transfer(Money.new(100_00), from: ryans_cash, to: ryans_savings, code: :xfer)
       expect(ryans_cash.balance).to eq(Money.new(-100_00))
       expect(ryans_savings.balance).to eq(Money.new(100_00))
     end

--- a/spec/performance/double_entry_performance_spec.rb
+++ b/spec/performance/double_entry_performance_spec.rb
@@ -4,8 +4,8 @@ module DoubleEntry
       include PerformanceHelper
       let(:user) { create(:user) }
       let(:amount) { Money.new(10_00) }
-      let(:test) { DoubleEntry.account(:test, :scope => user) }
-      let(:savings) { DoubleEntry.account(:savings, :scope => user) }
+      let(:test) { DoubleEntry.account(:test, scope: user) }
+      let(:savings) { DoubleEntry.account(:savings, scope: user) }
 
       it 'creates a lot of transfers quickly without metadata' do
         profile_transfers_with_metadata(nil)
@@ -31,7 +31,7 @@ module DoubleEntry
 
     def profile_transfers_with_metadata(metadata, profile_name = nil)
       start_profiling
-      options = { :from => test, :to => savings, :code => :bonus }
+      options = { from: test, to: savings, code: :bonus }
       options[:metadata] = metadata if metadata
       100.times { Transfer.transfer(amount, options) }
       profile_name ||= 'transfer'

--- a/spec/support/accounts.rb
+++ b/spec/support/accounts.rb
@@ -4,22 +4,22 @@ DoubleEntry.configure do |config|
   # A set of accounts to test with
   config.define_accounts do |accounts|
     user_scope = lambda{|user| user.id}
-    accounts.define(:identifier => :savings,     :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :checking,    :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :test,        :scope_identifier => user_scope)
-    accounts.define(:identifier => :btc_test,    :scope_identifier => user_scope, :currency => 'BTC')
-    accounts.define(:identifier => :btc_savings, :scope_identifier => user_scope, :currency => 'BTC')
-    accounts.define(:identifier => :deposit_fees, :scope_identifier => user_scope, :positive_only => true)
-    accounts.define(:identifier => :account_fees, :scope_identifier => user_scope, :positive_only => true)
+    accounts.define(identifier: :savings,     scope_identifier: user_scope, positive_only: true)
+    accounts.define(identifier: :checking,    scope_identifier: user_scope, positive_only: true)
+    accounts.define(identifier: :test,        scope_identifier: user_scope)
+    accounts.define(identifier: :btc_test,    scope_identifier: user_scope, currency: 'BTC')
+    accounts.define(identifier: :btc_savings, scope_identifier: user_scope, currency: 'BTC')
+    accounts.define(identifier: :deposit_fees, scope_identifier: user_scope, positive_only: true)
+    accounts.define(identifier: :account_fees, scope_identifier: user_scope, positive_only: true)
   end
 
   # A set of allowed transfers between accounts
   config.define_transfers do |transfers|
-    transfers.define(:from => :test,     :to => :savings,      :code => :bonus)
-    transfers.define(:from => :test,     :to => :checking,     :code => :pay)
-    transfers.define(:from => :savings,  :to => :test,         :code => :test_withdrawal)
-    transfers.define(:from => :btc_test, :to => :btc_savings,  :code => :btc_test_transfer)
-    transfers.define(:from => :savings,  :to => :deposit_fees, :code => :fee)
-    transfers.define(:from => :savings,  :to => :account_fees, :code => :fee)
+    transfers.define(from: :test,     to: :savings,      code: :bonus)
+    transfers.define(from: :test,     to: :checking,     code: :pay)
+    transfers.define(from: :savings,  to: :test,         code: :test_withdrawal)
+    transfers.define(from: :btc_test, to: :btc_savings,  code: :btc_test_transfer)
+    transfers.define(from: :savings,  to: :deposit_fees, code: :fee)
+    transfers.define(from: :savings,  to: :account_fees, code: :fee)
   end
 end

--- a/spec/support/double_entry_spec_helper.rb
+++ b/spec/support/double_entry_spec_helper.rb
@@ -2,44 +2,44 @@
 module DoubleEntrySpecHelper
   def lines_for_account(account)
     lines = DoubleEntry::Line.order(:id)
-    lines = lines.where(:scope => account.scope_identity) if account.scoped?
-    lines = lines.where(:account => account.identifier.to_s)
+    lines = lines.where(scope: account.scope_identity) if account.scoped?
+    lines = lines.where(account: account.identifier.to_s)
     lines
   end
 
   def perform_deposit(user, amount)
     DoubleEntry.transfer(
       Money.new(amount),
-      :from => DoubleEntry.account(:test, :scope => user),
-      :to   => DoubleEntry.account(:savings, :scope => user),
-      :code => :bonus,
+      from: DoubleEntry.account(:test, scope: user),
+      to:    DoubleEntry.account(:savings, scope: user),
+      code: :bonus,
     )
   end
 
   def transfer_deposit_fee(user, amount)
     DoubleEntry.transfer(
       Money.new(amount),
-      :from => DoubleEntry.account(:savings, :scope => user),
-      :to   => DoubleEntry.account(:deposit_fees, :scope => user),
-      :code => :fee,
+      from: DoubleEntry.account(:savings, scope: user),
+      to:    DoubleEntry.account(:deposit_fees, scope: user),
+      code: :fee,
     )
   end
 
   def transfer_account_fee(user, amount)
     DoubleEntry.transfer(
       Money.new(amount),
-      :from => DoubleEntry.account(:savings, :scope => user),
-      :to   => DoubleEntry.account(:account_fees, :scope => user),
-      :code => :fee,
+      from: DoubleEntry.account(:savings, scope: user),
+      to:    DoubleEntry.account(:account_fees, scope: user),
+      code: :fee,
     )
   end
 
   def perform_btc_deposit(user, amount)
     DoubleEntry.transfer(
       Money.new(amount, :btc),
-      :from => DoubleEntry.account(:btc_test, :scope => user),
-      :to   => DoubleEntry.account(:btc_savings, :scope => user),
-      :code => :btc_test_transfer,
+      from: DoubleEntry.account(:btc_test, scope: user),
+      to:    DoubleEntry.account(:btc_savings, scope: user),
+      code: :btc_test_transfer,
     )
   end
 end

--- a/spec/support/gemfiles/Gemfile.rails-4.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-4.2.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path => '../../../'
+gemspec path: '../../../'
 
 gem 'activerecord', '~> 4.2.0'
 

--- a/spec/support/gemfiles/Gemfile.rails-5.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.0.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path => '../../../'
+gemspec path: '../../../'
 
 gem 'activerecord', '~> 5.0.0'
 

--- a/spec/support/gemfiles/Gemfile.rails-5.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.1.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path => '../../../'
+gemspec path: '../../../'
 
 gem 'activerecord', '~> 5.1.0'
 

--- a/spec/support/gemfiles/Gemfile.rails-5.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.2.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path => '../../../'
+gemspec path: '../../../'
 
 gem 'activerecord', '~> 5.2.0'
 

--- a/spec/support/gemfiles/Gemfile.rails-6.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-6.0.x
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gemspec :path => '../../../'
+gemspec path: '../../../'
 
 gem 'activerecord', '~> 6.0.0'
 

--- a/spec/support/performance_helper.rb
+++ b/spec/support/performance_helper.rb
@@ -14,7 +14,7 @@ module PerformanceHelper
         outdir = './profiles'
         Dir.mkdir(outdir) unless Dir.exist?(outdir)
         printer = RubyProf::MultiPrinter.new(result)
-        printer.print(:path => outdir, :profile => profile_name)
+        printer.print(path: outdir, profile: profile_name)
       end
     end
     result

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,26 +1,26 @@
 ActiveRecord::Schema.define do
   self.verbose = false
 
-  create_table "double_entry_account_balances", :force => true do |t|
-    t.string     "account", :null => false
+  create_table "double_entry_account_balances", force: true do |t|
+    t.string     "account", null: false
     t.string     "scope"
-    t.bigint     "balance", :null => false
-    t.timestamps            :null => false
+    t.bigint     "balance", null: false
+    t.timestamps            null: false
   end
 
-  add_index "double_entry_account_balances", ["account"],          :name => "index_account_balances_on_account"
-  add_index "double_entry_account_balances", ["scope", "account"], :name => "index_account_balances_on_scope_and_account", :unique => true
+  add_index "double_entry_account_balances", ["account"],          name: "index_account_balances_on_account"
+  add_index "double_entry_account_balances", ["scope", "account"], name: "index_account_balances_on_scope_and_account", unique: true
 
-  create_table "double_entry_lines", :force => true do |t|
-    t.string     "account",         :null => false
+  create_table "double_entry_lines", force: true do |t|
+    t.string     "account",         null: false
     t.string     "scope"
-    t.string     "code",            :null => false
-    t.bigint     "amount",          :null => false
-    t.bigint     "balance",         :null => false
-    t.references "partner",                         :index => false
-    t.string     "partner_account", :null => false
+    t.string     "code",            null: false
+    t.bigint     "amount",          null: false
+    t.bigint     "balance",         null: false
+    t.references "partner",                         index: false
+    t.string     "partner_account", null: false
     t.string     "partner_scope"
-    t.references "detail",                          :index => false, :polymorphic => true
+    t.references "detail",                          index: false, polymorphic: true
     unless ActiveRecord.version.version < '5'
       if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
         t.jsonb "metadata"
@@ -28,37 +28,37 @@ ActiveRecord::Schema.define do
         t.json "metadata"
       end
     end
-    t.timestamps                    :null => false
+    t.timestamps                    null: false
   end
 
-  add_index "double_entry_lines", ["account", "code", "created_at", "partner_account"],  :name => "lines_account_code_created_at_partner_account_idx"
-  add_index "double_entry_lines", ["account", "created_at"],                             :name => "lines_account_created_at_idx"
-  add_index "double_entry_lines", ["scope", "account", "created_at"],                    :name => "lines_scope_account_created_at_idx"
-  add_index "double_entry_lines", ["scope", "account", "id"],                            :name => "lines_scope_account_id_idx"
+  add_index "double_entry_lines", ["account", "code", "created_at", "partner_account"],  name: "lines_account_code_created_at_partner_account_idx"
+  add_index "double_entry_lines", ["account", "created_at"],                             name: "lines_account_created_at_idx"
+  add_index "double_entry_lines", ["scope", "account", "created_at"],                    name: "lines_scope_account_created_at_idx"
+  add_index "double_entry_lines", ["scope", "account", "id"],                            name: "lines_scope_account_id_idx"
 
-  create_table "double_entry_line_checks", :force => true do |t|
-    t.references "last_line",    :null => false, :index => false
-    t.boolean    "errors_found", :null => false
+  create_table "double_entry_line_checks", force: true do |t|
+    t.references "last_line",    null: false, index: false
+    t.boolean    "errors_found", null: false
     t.text       "log"
-    t.timestamps                 :null => false
+    t.timestamps                 null: false
   end
 
-  add_index "double_entry_line_checks", ["created_at", "last_line_id"], :name => "line_checks_created_at_last_line_id_idx"
+  add_index "double_entry_line_checks", ["created_at", "last_line_id"], name: "line_checks_created_at_last_line_id_idx"
 
-  create_table "double_entry_line_metadata", :force => true do |t|
-    t.references "line",    :null => false, :index => false
-    t.string     "key",     :null => false
-    t.string     "value",   :null => false
-    t.timestamps            :null => false
+  create_table "double_entry_line_metadata", force: true do |t|
+    t.references "line",    null: false, index: false
+    t.string     "key",     null: false
+    t.string     "value",   null: false
+    t.timestamps            null: false
   end
 
-  add_index "double_entry_line_metadata", ["line_id", "key", "value"], :name => "lines_meta_line_id_key_value_idx"
+  add_index "double_entry_line_metadata", ["line_id", "key", "value"], name: "lines_meta_line_id_key_value_idx"
 
   # test table only
-  create_table "users", :force => true do |t|
-    t.string     "username", :null => false
-    t.timestamps             :null => false
+  create_table "users", force: true do |t|
+    t.string     "username", null: false
+    t.timestamps             null: false
   end
 
-  add_index "users", ["username"], :name => "index_users_on_username", :unique => true
+  add_index "users", ["username"], name: "index_users_on_username", unique: true
 end


### PR DESCRIPTION
Not sure how everyone feels about hashrockets, but I personally don't love them, especially given how many chars they take up. Considering the min ruby version is one that supports the new hash syntax, I figured I might as well give it a shot.