### PR TITLE
Make the Line detail association optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Use the Ruby 1.9 hash syntax ([#182]).
+- Make the Line detail association optional ([#184]).
 
 [Unreleased]: https://github.com/envato/double_entry/compare/v2.0.0.beta4...HEAD
 [#182]: https://github.com/envato/double_entry/pull/182
+[#184]: https://github.com/envato/double_entry/pull/184
 
 ## [2.0.0.beta4] - 2020-01-25
 

--- a/lib/double_entry/line.rb
+++ b/lib/double_entry/line.rb
@@ -55,7 +55,7 @@ module DoubleEntry
   # by account, or account and code, over a particular period.
   #
   class Line < ActiveRecord::Base
-    belongs_to :detail, polymorphic: true
+    belongs_to :detail, polymorphic: true, required: false
     has_many :metadata, class_name: 'DoubleEntry::LineMetadata' unless -> { DoubleEntry.config.json_metadata }
     scope :with_id_greater_than, ->(id) { where('id > ?', id) }
 

--- a/spec/double_entry/line_spec.rb
+++ b/spec/double_entry/line_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe DoubleEntry::Line do
         let(:partner_account) { DoubleEntry.account(:btc_test, scope_identity: '72') }
         its(:currency) { should eq 'BTC' }
       end
+
+      context 'given detail = nil' do
+        specify { expect { line_to_persist.save! }.not_to raise_error(ActiveRecord::RecordInvalid) }
+      end
     end
 
     context 'when balance is sent negative' do

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -11,6 +11,7 @@ raise <<-MSG.strip_heredoc unless File.exist?(database_config_file)
   See spec/support/database.example.yml'
 MSG
 
+ActiveRecord::Base.belongs_to_required_by_default = true if ActiveRecord.version.version >= '5'
 ActiveRecord::Base.establish_connection(YAML.load_file(database_config_file)[db_engine])
 
 RSpec.configure do |config|


### PR DESCRIPTION
`belongs_to` associations became required by default unless specified otherwise from Rails 5.0 and this explicitly sets the `detail` association on `Line` to optional. I used `required: false` instead of `optional: true` because the `optional` option was only added in Rails 5, but `required` will work in Rails < 5. Fixes #183 