### PR TITLE
Test against Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,24 @@ matrix:
       gemfile: spec/support/gemfiles/Gemfile.rails-5.2.x
       env: DB=mysql
     - rvm: 2.7
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=mysql
+    - rvm: 2.7
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=sqlite
+    - rvm: 2.7
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=postgres
+    - rvm: 3.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=mysql
+    - rvm: 3.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=sqlite
+    - rvm: 3.0
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      env: DB=postgres
+    - rvm: 2.7
       gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=mysql
     - rvm: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,20 +29,20 @@ matrix:
       gemfile: spec/support/gemfiles/Gemfile.rails-5.2.x
       env: DB=mysql
     - rvm: 2.7
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=mysql
     - rvm: 2.7
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=sqlite
     - rvm: 2.7
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=postgres
     - rvm: 3.0
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=mysql
     - rvm: 3.0
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=sqlite
     - rvm: 3.0
-      gemfile: spec/support/gemfiles/Gemfile.rails-6.0.x
+      gemfile: spec/support/gemfiles/Gemfile.rails-6.1.x
       env: DB=postgres

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Rails
  * 5.1.x
  * 5.2.x
  * 6.0.x
+ * 6.1.x
 
 Databases
  * MySQL

--- a/spec/support/gemfiles/Gemfile.rails-6.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-6.1.x
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '../../../'
+
+gem 'activerecord', '~> 6.1.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+gem 'mysql2', '>= 0.5'


### PR DESCRIPTION
This is a potential fix for https://github.com/envato/double_entry/issues/200

The tests pass locally before and after these changes but that isn't surprising given the nature of the changes.

https://railsbump.org/gems/double_entry claims 6.1 is fine. Waiting to see the result of the Travis run. I'm not entirely sure how else to validate this so if this isn't correct or more needs doing let me know :)