### PR TITLE
Closed #206 - AccountFixer unsupported unscoped account

### DIFF
--- a/lib/double_entry/validation/account_fixer.rb
+++ b/lib/double_entry/validation/account_fixer.rb
@@ -23,7 +23,7 @@ module DoubleEntry
       def lines_for_account(account)
         Line.where(
           account: account.identifier.to_s,
-          scope: account.scope_identity.to_s
+          scope: account.scope_identity&.to_s
         ).order(:id)
       end
 


### PR DESCRIPTION
This is related to #206 which ensure `LineCheck` and `AccountFixer` can correct detect `unscoped` account (`scope = nil`) and fix to the correct balance.

> This is a proposal way, we can discuss more.