### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -9,15 +9,6 @@ jobs:
         gemfile: [Gemfile.rails-6.1.x, Gemfile.rails-7.0.x]
         db: [mysql, postgres, sqlite]
         include:
-          - ruby: 2.5
-            gemfile: Gemfile.rails-5.0.x
-            db: mysql
-          - ruby: 2.5
-            gemfile: Gemfile.rails-5.1.x
-            db: mysql
-          - ruby: 2.6
-            gemfile: Gemfile.rails-5.2.x
-            db: mysql
           - ruby: 2.7
             gemfile: Gemfile.rails-6.0.x
             db: mysql

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        ruby: ['2.7', '3.0', '3.1', '3.2']
+        gemfile: [Gemfile.rails-6.1.x, Gemfile.rails-7.0.x]
+        db: [mysql, postgres, sqlite]
         include:
           - ruby: 2.5
             gemfile: Gemfile.rails-5.0.x
@@ -18,39 +21,6 @@ jobs:
           - ruby: 2.7
             gemfile: Gemfile.rails-6.0.x
             db: mysql
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.0.x
-            db: sqlite
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.0.x
-            db: postgres
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.0.x
-            db: mysql
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.0.x
-            db: sqlite
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.0.x
-            db: postgres
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.1.x
-            db: mysql
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.1.x
-            db: sqlite
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.1.x
-            db: postgres
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.1.x
-            db: mysql
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.1.x
-            db: sqlite
-          - ruby: 3.0
-            gemfile: Gemfile.rails-6.1.x
-            db: postgres
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/support/gemfiles/${{ matrix.gemfile }}
       DB: ${{ matrix.db }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Return `[credit, debit]` from `DoubleEntry.transfer` ([#190]).
+- Run the test suite against Rails 7.0, and Ruby 3.1, 3.2 ([#214]).
 
 [#190]: https://github.com/envato/double_entry/pull/190
+[#214]: https://github.com/envato/double_entry/pull/214
 
 ## [2.0.0.beta5] - 2021-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Return `[credit, debit]` from `DoubleEntry.transfer` ([#190]).
 - Run the test suite against Rails 7.0, and Ruby 3.1, 3.2 ([#214]).
 
+### Removed
+
+- Removed support for Rails < 6.0, and Ruby < 2.7 ([#214]).
+
 [#190]: https://github.com/envato/double_entry/pull/190
 [#214]: https://github.com/envato/double_entry/pull/214
 

--- a/README.md
+++ b/README.md
@@ -22,20 +22,12 @@ DoubleEntry uses the [Money gem](https://github.com/RubyMoney/money) to encapsul
 DoubleEntry is tested against:
 
 Ruby
- * 2.3.x
- * 2.4.x
- * 2.5.x
- * 2.6.x
  * 2.7.x
  * 3.0.x
  * 3.1.x
  * 3.2.x
 
 Rails
- * 4.2.x
- * 5.0.x
- * 5.1.x
- * 5.2.x
  * 6.0.x
  * 6.1.x
  * 7.0.x

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Ruby
  * 2.5.x
  * 2.6.x
  * 2.7.x
+ * 3.0.x
+ * 3.1.x
+ * 3.2.x
 
 Rails
  * 4.2.x
@@ -35,6 +38,7 @@ Rails
  * 5.2.x
  * 6.0.x
  * 6.1.x
+ * 7.0.x
 
 Databases
  * MySQL

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |gem|
     f.match(%r{^(?:double_entry.gemspec|README|LICENSE|CHANGELOG|lib/)})
   end
   gem.require_paths         = ['lib']
-  gem.required_ruby_version = '>= 2.3.0'
+  gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_dependency 'activerecord',          '>= 3.2.0'
-  gem.add_dependency 'activesupport',         '>= 3.2.0'
+  gem.add_dependency 'activerecord',          '>= 6.0.0'
+  gem.add_dependency 'activesupport',         '>= 6.0.0'
   gem.add_dependency 'money',                 '>= 6.0.0'
-  gem.add_dependency 'railties',              '>= 3.2.0'
+  gem.add_dependency 'railties',              '>= 6.0.0'
 
   gem.add_development_dependency 'mysql2'
   gem.add_development_dependency 'pg'

--- a/spec/support/gemfiles/Gemfile.rails-4.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-4.2.x
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../../../'
-
-gem 'activerecord', '~> 4.2.0'
-
-# Rails imposed mysql2 version contraints
-# https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L3
-gem 'mysql2', '>= 0.3.13', '< 0.5'

--- a/spec/support/gemfiles/Gemfile.rails-5.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.0.x
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../../../'
-
-gem 'activerecord', '~> 5.0.0'
-
-# Rails imposed mysql2 version contraints
-# https://github.com/rails/rails/blob/5-0-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4
-gem 'mysql2', '>= 0.3.18', '< 0.6.0'

--- a/spec/support/gemfiles/Gemfile.rails-5.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.1.x
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../../../'
-
-gem 'activerecord', '~> 5.1.0'
-
-# Rails imposed mysql2 version contraints
-# https://github.com/rails/rails/blob/5-1-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L4
-gem 'mysql2', '>= 0.3.18', '< 0.6.0'

--- a/spec/support/gemfiles/Gemfile.rails-5.2.x
+++ b/spec/support/gemfiles/Gemfile.rails-5.2.x
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../../../'
-
-gem 'activerecord', '~> 5.2.0'
-
-# Rails imposed mysql2 version contraints
-# https://github.com/rails/rails/blob/5-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
-gem 'mysql2', '>= 0.4.4', '< 0.6.0'

--- a/spec/support/gemfiles/Gemfile.rails-7.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-7.0.x
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '../../../'
+
+gem 'activerecord', '~> 7.0.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+gem 'mysql2', '~> 0.5'


### PR DESCRIPTION
Configure the gemspec and CI matrix to use the current supported versions of Ruby and Rails:

#### Ruby
 * 2.7.x
 * 3.0.x
 * 3.1.x
 * 3.2.x

#### Rails
 * 6.0.x
 * 6.1.x
 * 7.0.x