### PR TITLE
Update supported Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.0', '3.1', '3.2']
-        gemfile: [Gemfile.rails-6.1.x, Gemfile.rails-7.0.x]
+        gemfile: [Gemfile.rails-6.1.x, Gemfile.rails-7.0.x, Gemfile.rails-7.1.x]
         db: [mysql, postgres, sqlite]
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/support/gemfiles/${{ matrix.gemfile }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,13 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
         gemfile: [Gemfile.rails-6.1.x, Gemfile.rails-7.0.x]
         db: [mysql, postgres, sqlite]
-        include:
-          - ruby: 2.7
-            gemfile: Gemfile.rails-6.0.x
-            db: mysql
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/spec/support/gemfiles/${{ matrix.gemfile }}
       DB: ${{ matrix.db }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-ruby '>= 2.3.0'
 gemspec

--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -24,12 +24,12 @@ Gem::Specification.new do |gem|
     f.match(%r{^(?:double_entry.gemspec|README|LICENSE|CHANGELOG|lib/)})
   end
   gem.require_paths         = ['lib']
-  gem.required_ruby_version = '>= 2.7.0'
+  gem.required_ruby_version = '>= 3'
 
-  gem.add_dependency 'activerecord',          '>= 6.0.0'
-  gem.add_dependency 'activesupport',         '>= 6.0.0'
+  gem.add_dependency 'activerecord',          '>= 6.1.0'
+  gem.add_dependency 'activesupport',         '>= 6.1.0'
   gem.add_dependency 'money',                 '>= 6.0.0'
-  gem.add_dependency 'railties',              '>= 6.0.0'
+  gem.add_dependency 'railties',              '>= 6.1.0'
 
   gem.add_development_dependency 'mysql2'
   gem.add_development_dependency 'pg'

--- a/spec/support/gemfiles/Gemfile.rails-6.0.x
+++ b/spec/support/gemfiles/Gemfile.rails-6.0.x
@@ -1,9 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../../../'
-
-gem 'activerecord', '~> 6.0.0'
-
-# Rails imposed mysql2 version contraints
-# https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
-gem 'mysql2', '>= 0.4.4'

--- a/spec/support/gemfiles/Gemfile.rails-7.1.x
+++ b/spec/support/gemfiles/Gemfile.rails-7.1.x
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gemspec path: '../../../'
+
+gem 'activerecord', '~> 7.1.0'
+
+# Rails imposed mysql2 version contraints
+# https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6
+gem 'mysql2', '~> 0.5'


### PR DESCRIPTION
Configure the gemspec and CI matrix to use the current supported versions of Ruby and Rails:

#### Ruby

 * 3.0.x
 * 3.1.x
 * 3.2.x

#### Rails

 * 6.1.x
 * 7.0.x
 * 7.1.x