### PR TITLE
Fix Rails 7.1 coder deprecation warning

### DIFF
--- a/lib/double_entry/line_metadata.rb
+++ b/lib/double_entry/line_metadata.rb
@@ -13,6 +13,6 @@ module DoubleEntry
     end
 
     belongs_to :line
-    serialize :key, SymbolWrapper
+    serialize :key, coder: DoubleEntry::LineMetadata::SymbolWrapper
   end
 end


### PR DESCRIPTION
### What
Passing in `coder` as a named argument instead of a positional argument. This will no longer be supporter in Rails 7.2 and currently throws a deprecation warning in Rails 7.1.

For reference:
<img width="1484" alt="Screen Shot 2023-11-01 at 12 53 51 pm" src="https://github.com/envato/double_entry/assets/4738104/2851bcac-6b00-4310-aaf2-f0fd4576a12a">
